### PR TITLE
Chore: redux-toolkit setting

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
+
+// DESC: state management
+import store from './store';
 
 // DESC: import global css
 import './styles/global.css';
@@ -14,7 +18,9 @@ const root = ReactDOM.createRoot(
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </React.StrictMode>,
 );
 

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,0 +1,7 @@
+import { useDispatch, useSelector, TypedUseSelectorHook } from 'react-redux';
+
+import type { RootState, AppDispatch } from '.';
+
+// DESC: useAppDispatch, useAppSelector <- useDispatch, useSelector의 타입 정보가 해결된 훅
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,19 @@
+import { configureStore } from '@reduxjs/toolkit';
+import rootReducer from './slices';
+
+// DESC: configureStore로 생성된 store - 다양한 기능을 갖춘 store, state들을 관리하는 공간
+const store = configureStore({
+  // DESC: rootReducer <- 우리의 redux state들 모음, slice들의 집합
+  reducer: rootReducer,
+});
+
+// DESC: store의 타입 사용시
+export type StoreType = typeof store;
+
+// DESC: dispatch의 타입 사용시
+export type AppDispatch = typeof store.dispatch;
+
+// DESC: 기본 state의 타입 사용시
+export type RootState = ReturnType<typeof store.getState>;
+
+export default store;

--- a/src/store/slices/counterSlice.ts
+++ b/src/store/slices/counterSlice.ts
@@ -1,0 +1,94 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+type SliceState = {
+  num: number;
+};
+
+const initialState: SliceState = {
+  // DESC: 초기값 지정, 객체 형태
+  num: 0,
+};
+
+const counterSlice = createSlice({
+  name: 'counter', // DESC: 직접 사용할 reducer 이름을 정의
+  initialState,
+  reducers: {
+    // DESC: state 변경해주는 함수 등록, 여러 개 가능
+    increment: state => {
+      state.num += 1;
+    },
+    decrement: state => {
+      state.num -= 1;
+    },
+    // DESC: payload가 있는 경우
+    incrementByAmount: (state, action: PayloadAction<number>) => {
+      state.num += action.payload;
+    },
+  },
+  /*
+  extraReducers: (builder) => {
+    builder.addCase(updateUser.fulfilled, (state, { payload }) => {
+      state.entities[payload.id] = payload
+    })
+    builder.addCase(updateUser.rejected, (state, action) => {
+      if (action.payload) {
+        // Since we passed in `MyKnownError` to `rejectValue` in `updateUser`, the type information will be available here.
+        state.error = action.payload.errorMessage
+      } else {
+        state.error = action.error
+      }
+    })
+  },
+  */
+});
+
+/*
+// DESC: 🚀비동기 처리를 위한 createAsyncThunk 예시
+
+interface MyKnownError {
+  errorMessage: string
+  // ...
+}
+
+interface UserAttributes {
+  id: string
+  first_name: string
+  last_name: string
+  email: string
+}
+
+const updateUser = createAsyncThunk<
+  // Return type of the payload creator
+  MyData,
+  // First argument to the payload creator
+  UserAttributes,
+  // Types for ThunkAPI
+  {
+    extra: {
+      jwt: string
+    }
+    rejectValue: MyKnownError
+  }
+>('users/update', async (user, thunkApi) => {
+  const { id, ...userData } = user
+  const response = await fetch(`https://reqres.in/api/users/${id}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${thunkApi.extra.jwt}`,
+    },
+    body: JSON.stringify(userData),
+  })
+  if (response.status === 400) {
+    // Return the known error for future handling
+    return thunkApi.rejectWithValue((await response.json()) as MyKnownError)
+  }
+  return (await response.json()) as MyData
+})
+
+*/
+
+// DESC: Action creators are generated for each case reducer function
+// DESC: 작성한 기능 사용, counterSlice안에 actions에 담겨 있음
+export const counterActions = counterSlice.actions;
+
+export default counterSlice.reducer;

--- a/src/store/slices/index.ts
+++ b/src/store/slices/index.ts
@@ -1,0 +1,11 @@
+// DESC: 만든 slice(reducer + action)들을 합쳐주는 곳
+
+import { combineReducers } from '@reduxjs/toolkit';
+import counterSlice from './counterSlice';
+
+// DESC: 여러 종류의 slice들을 여기서 합쳐줌
+const rootReducer = combineReducers({
+  counter: counterSlice,
+});
+
+export default rootReducer;


### PR DESCRIPTION
## 🙌 To Reviewers
* Redux-toolkit 관련 세팅입니다.
* 큰 흐름은 아래와 같습니다.
  * 📁 src/store/slices 에서 각각 상태에 해당하는 📄 slice를 만든다.
  * 📄 src/store/slices/index.ts 에 만든 slice를 추가한다.
  * 필요한 곳에서 `useAppDispatch` (<- 커스텀 훅, 원래는 `useDispatch` from `react-redux`)를 통해 상태를 업데이트 해준다.
  * 상태가 필요한 곳에서 `useAppSelector` (<- 커스텀 훅, 원래는 `useSelector` from `react-redux`)을 통해 상태를 가져와 사용한다. 

* 이 외에 다른 부분은 `// DESC:` 로 설명 남겨놓긴 했는데,
개선하고 싶은 부분 있으시면 코멘트 주시거나 혹은 후에 구현하다가도 편하게 말씀해주시면 감사할 것 같슴다!
* 위 흐름 잡고 독스 Usage 쭉 보시면 좋을 것 같은데
저는 `configureStore`, `createSlice`, `createAsyncThunk` 부분 참고해서 세팅했고 아래 링크 글들도 살펴봤어서 주소 남길게요 🔎
* [<공식문서> Redux-toolkit Docs, Usage With TypeScript](https://redux-toolkit.js.org/usage/usage-with-typescript#configurestore)
[velog-Redux-docs-tutorial-setting](https://velog.io/@hongduhyeon/Redux-docs-tutorial-setting)
[velog-Redux-toolkit with Next.js](https://velog.io/@rdt419/Redux-toolkit-%EC%82%AC%EC%9A%A9%EB%B2%95feat.-Next-js)
마지막 글은 next.js에서의 세팅인데 역할을 좀 쉽게 풀어놓은 것 같아서, 관련 없는 내용 넘기고 필요한 용어만 보셔도 괜찮을 것 같아 남겨요!
* ++ counterSlice로 들어있는 건 예시만 남긴거라 안돌아갈거에요..! 후에 주석이랑 같이 제거할게요
* 카운터 예제도 남길게요! 코드 샌드박스 들어가시면 동작하는 코드 있으니까 바꾸면서 놀아보셔유,,
[CodeSandbox - counter with redux toolkit](https://codesandbox.io/s/bold-snowflake-29br7x?file=/src/features/counter/counterSlice.js)

<br>

## 🔑 Key Changes
### structure
```
📁 src/store
    📁 slices
        📄 index.ts (🔺 각각의 slice들을 합쳐서 rootReducer을 만듦(리듀서 병합))
        📄 counterSlice.ts (🔺 createSlice, 각 상태 별로 비슷한 slice 만들면 됨)
        📄 user.ts (example)
        📄 profile.ts (example)
        📄 ...
    📄 hooks.ts (🔺 useDispatch와 useSelector의 타입 정보 서술을 해결한 훅 useAppDispatch, useAppSelector) 
    📄 index.ts (🔺 store에 rootReducer 연결)
```

<br>

## ScreenShot (optional)
❌
