### PR TITLE
feat: 로그인시 store에 accessToken 저장 & useAuth hook 작성

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,76 @@
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+
+import { getMe } from '../store/slices/usersSlice';
+import { postLogin } from '../store/slices/sessionSlice';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
+
+export const useAuth = () => {
+  const dispatch = useAppDispatch();
+  const { me } = useAppSelector(state => state.users);
+  const { accessToken } = useAppSelector(state => state.session);
+  const [sessionLoading, setSessionLoading] = useState(true);
+  // const [errorStatus, setErrorStatus] = useState(0);
+
+  useEffect(() => {
+    if (!accessToken) {
+      // TODO: 후에 postLogin -> getRefresh()로 바꿔주기
+      dispatch(postLogin({ email: '123@naver.com', password: 'rlawhkgns123!' }))
+        .unwrap()
+        .then(res => {
+          // TODO: 얻어오는 정보 확인해서 토큰 뽑아주기
+          dispatch(getMe(res.accessToken))
+            .unwrap()
+            .then(() => {
+              setSessionLoading(false);
+            })
+            .catch(err => {
+              console.log(err);
+              // TODO: 케이스 따라 적절한 에러코드 setting
+            });
+        })
+        .catch(err => {
+          if (axios.isAxiosError(err)) {
+            // TODO: 케이스 따라 적절한 에러코드 setting
+          }
+        });
+    } else {
+      dispatch(getMe(accessToken))
+        .unwrap()
+        .then(() => {
+          setSessionLoading(false);
+        })
+        .catch(() => {
+          // TODO: 후에 postLogin -> getRefresh()로 바꿔주기
+          dispatch(
+            postLogin({ email: '123@naver.com', password: 'rlawhkgns123!' }),
+          )
+            .unwrap()
+            .then(res => {
+              // TODO: 얻어오는 정보 확인해서 토큰 뽑아주기
+              dispatch(getMe(res.accessToken))
+                .unwrap()
+                .then(() => {
+                  setSessionLoading(false);
+                })
+                .catch(err => {
+                  console.log(err);
+                  // TODO: 케이스 따라 적절한 에러코드 setting
+                });
+            })
+            .catch(err => {
+              if (axios.isAxiosError(err)) {
+                // TODO: 케이스 따라 적절한 에러코드 setting
+              }
+            });
+        });
+    }
+  }, []);
+
+  return {
+    me,
+    accessToken,
+    // errorStatus,
+    sessionLoading,
+  };
+};

--- a/src/store/slices/sessionSlice.ts
+++ b/src/store/slices/sessionSlice.ts
@@ -5,7 +5,7 @@ import { BASE_URL } from '../../constant';
 import { LoginInput } from '../../types/auth';
 
 export const postLogin = createAsyncThunk(
-  'users/postLogin',
+  'session/postLogin',
   async ({ email, password }: LoginInput, { rejectWithValue }) => {
     try {
       const res = await axios.post(`${BASE_URL}/auth/login`, {
@@ -14,7 +14,6 @@ export const postLogin = createAsyncThunk(
       });
       return res.data;
     } catch (err) {
-      // DESC: 컴포넌트쪽에서 에러처리할 수 있게 에러 export
       return rejectWithValue(err);
     }
   },
@@ -32,13 +31,10 @@ const initialState: sessionSliceState = {
 export const sessionSlice = createSlice({
   name: 'session',
   initialState,
-  reducers: {
-    // 비동기 아닌 부분
-  },
+  reducers: {},
   extraReducers: builder => {
     builder.addCase(postLogin.fulfilled, (state, action) => {
-      // action.payload에 뭐 담겨오는지 확인하시고 맞게 적어주시면 될듯 합니다..!
-      state.accessToken = action.payload;
+      state.accessToken = action.payload.accessToken;
     });
   },
 });


### PR DESCRIPTION
## 🙌 To Reviewers
* 일단 구현 사항 올리기 전에 로그인 토큰 저장하는 것만 올리면 좋을 것 같아서 이거 먼저 pr 날립니다.
* 로그인할 때 받은 accessToken 스토어에 저장해주는 thunk 함수 간단히 작성했습니다. 
* (미완성) `useAuth()` 훅을 작성했는데요, 후에 토큰 리프레시(아직 안되었지만 후에 구현될 것이라고 하셔서) + 접근 권한이 있는 페이지를 관리할 필요가 있겠다 싶어서 썼습니다..!
* 그냥 기존에 썼던 것처럼 `useAuth` 내부에서 _내 정보_ 랑 _accessToken_ 관련된 정보 state로 선언해서 Return 해줄 수도 있지만, store에 저장하는 과정도 같이 가져가고 싶어서 thunk 함수 처리해서 했더니 (useAuth 내부에서) useEffect 바깥에서는 계속 스토어 정보 확인해주고 있고, api 호출하는 응답에서 로딩 중인지 아닌지만 세팅하면 돼서 좀 편한 느낌이라고 생각했어요
* 아래는 그냥 간단한 사용이나 권한별 에러, 리프레시 어떻게 처리하면 좋을지 생각해봤는데 다음 회의 때 얘기 나눠봐도 좋을 것 같습니다!
* 훅이 좀 지저분한가 싶어서 내용 채우면서 수정하는 방향으로 해볼게요..
https://garrulous-philosophy-1a3.notion.site/Waffle-market-d175bc9bf74e43a496b0ea3e8e867c23
```typescript
//.. 컴포넌트 내부
const { errorStatus, sessionLoading, accessToken, me } = useAuth();

  useEffect(() => {
    if (!sessionLoading && 에러 아닐 때) {
      console.log('sessionLoading', sessionLoading);
      console.log('accessToken', accessToken);
      console.log('me', me);
      // 해주고 싶은 작업
    }
  }, [sessionLoading]);
  
  if (sessionLoading) {
    return <div>로딩 중...</div>;
  }

  if (!sessionLoading && errorStatus === 401) {
    return <div>예: 로그인 페이지로</div>;
  }

// early return문 아래에는 state 선언 안됨

// 리턴 
```
