### PR TITLE
Feat: 검색방식 변경 / 페이지네이션 外

### DIFF
--- a/src/pages/buy-history/buy-history.styled.tsx
+++ b/src/pages/buy-history/buy-history.styled.tsx
@@ -18,6 +18,7 @@ export const Header = styled.div`
 
   @media ${MD_SIZE} {
     width: 100vw;
+    margin-top: 20px;
   }
 `;
 
@@ -72,6 +73,7 @@ export const List = styled.div`
     column-gap: 0;
     width: 100vw;
     padding: 0;
+    border-bottom: 0.5px solid #8a8a8a;
   }
 
   @media ${Market_MD} {

--- a/src/pages/buy-history/components/shortcut/index.tsx
+++ b/src/pages/buy-history/components/shortcut/index.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import Moment from 'react-moment';
+import { toStringNumWithComma } from '../../../../utils/tradePost';
 import {
   Container,
   Img,
@@ -64,7 +65,7 @@ const ShortCut = ({
           {tradeStatus !== 'TRADING' && (
             <TradeStatusButton tradeStatus={tradeStatus} />
           )}
-          <Price>{price}원</Price>
+          <Price>{toStringNumWithComma(price)}원</Price>
         </PriceBox>
         <Location>{location}</Location>
         <Detail>

--- a/src/pages/buy-history/components/shortcut/shortcut.styled.tsx
+++ b/src/pages/buy-history/components/shortcut/shortcut.styled.tsx
@@ -21,9 +21,7 @@ export const Container = styled.div`
     align-content: center;
     width: 100%;
     height: 180px;
-    border-top: 0.5px solid black;
-    border-bottom: 0.5px solid black;
-    border-collapse: collapse;
+    border-top: 0.5px solid #8a8a8a;
     border-radius: 0;
     gap: 4px;
   }

--- a/src/pages/buy-history/components/shortcut/shortcut.styled.tsx
+++ b/src/pages/buy-history/components/shortcut/shortcut.styled.tsx
@@ -35,6 +35,7 @@ export const Img = styled.img`
   border: 1px solid transparent;
   border-radius: 12px;
   margin-bottom: 4px;
+  object-fit: cover;
 
   @media ${MD_SIZE} {
     width: 160px;

--- a/src/pages/buy-history/index.tsx
+++ b/src/pages/buy-history/index.tsx
@@ -22,8 +22,7 @@ const BuyHistoryPage = () => {
       dispatch(getBuyHistory(accessToken as string))
         .unwrap()
         .then(res => {
-          console.log(res);
-          setData(res.posts);
+          setData(res.posts.reverse());
         })
         .catch(err => {
           if (axios.isAxiosError(err)) {

--- a/src/pages/like-history/components/shortcut/index.tsx
+++ b/src/pages/like-history/components/shortcut/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import Moment from 'react-moment';
+import { toStringNumWithComma } from '../../../../utils/tradePost';
 import {
   Container,
   Img,
@@ -72,7 +73,7 @@ const ShortCut = ({
           {tradeStatus !== 'TRADING' && (
             <TradeStatusButton tradeStatus={tradeStatus} />
           )}
-          <Price>{price}원</Price>
+          <Price>{toStringNumWithComma(price)}원</Price>
         </PriceBox>
         <Location>{location}</Location>
         <Detail>

--- a/src/pages/like-history/components/shortcut/shortcut.styled.tsx
+++ b/src/pages/like-history/components/shortcut/shortcut.styled.tsx
@@ -21,9 +21,7 @@ export const Container = styled.div`
     align-content: center;
     width: 100%;
     height: 180px;
-    border-top: 0.5px solid black;
-    border-bottom: 0.5px solid black;
-    border-collapse: collapse;
+    border-top: 0.5px solid #8a8a8a;
     border-radius: 0;
     gap: 4px;
   }
@@ -52,6 +50,11 @@ export const Heart = styled.img`
   top: 208px;
   width: 24px;
   z-index: 1;
+
+  @media ${MD_SIZE} {
+    top: 146px;
+    right: 10px;
+  }
 `;
 
 export const Info = styled.div`

--- a/src/pages/like-history/components/shortcut/shortcut.styled.tsx
+++ b/src/pages/like-history/components/shortcut/shortcut.styled.tsx
@@ -46,7 +46,7 @@ export const Img = styled.img`
 
 export const Heart = styled.img`
   position: absolute;
-  right: 2px;
+  right: 4px;
   top: 208px;
   width: 24px;
   z-index: 1;

--- a/src/pages/like-history/components/shortcut/shortcut.styled.tsx
+++ b/src/pages/like-history/components/shortcut/shortcut.styled.tsx
@@ -35,6 +35,7 @@ export const Img = styled.img`
   border: 1px solid transparent;
   border-radius: 12px;
   margin-bottom: 4px;
+  object-fit: cover;
 
   @media ${MD_SIZE} {
     width: 160px;

--- a/src/pages/like-history/index.tsx
+++ b/src/pages/like-history/index.tsx
@@ -25,8 +25,7 @@ const LikeHistoryPage = () => {
       dispatch(getLikeHistory(accessToken as string))
         .unwrap()
         .then(res => {
-          console.log(res);
-          setData(res.posts);
+          setData(res.posts.reverse());
         })
         .catch(err => {
           if (axios.isAxiosError(err)) {

--- a/src/pages/like-history/like-history.styled.tsx
+++ b/src/pages/like-history/like-history.styled.tsx
@@ -18,6 +18,7 @@ export const Header = styled.div`
 
   @media ${MD_SIZE} {
     width: 100vw;
+    margin-top: 20px;
   }
 `;
 
@@ -71,7 +72,7 @@ export const List = styled.div`
     row-gap: 0;
     column-gap: 0;
     width: 100vw;
-    padding: 0;
+    border-bottom: 0.5px solid #8a8a8a;
   }
 
   @media ${Market_MD} {

--- a/src/pages/market/components/pagination/index.tsx
+++ b/src/pages/market/components/pagination/index.tsx
@@ -1,4 +1,6 @@
-import { Wrapper, Button } from './pagination.styled';
+import { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
+import { Wrapper, Move, More, Button } from './pagination.styled';
 
 const Pagination = ({
   total,
@@ -9,19 +11,71 @@ const Pagination = ({
   page: number;
   setPage: (page: number) => void;
 }) => {
+  // DESC: n = 한 줄에 보이는 페이지 버튼 수
+  // TODO: 현재 테스트용으로 3페이지씩 보이도록 했으나 게시물 수 늘어나면 n=5로 변경 예정
+  const n = 3;
+  const [pageHead, setPageHead] = useState<number>(
+    Math.floor((page - 1) / n) * n + 1,
+  );
+  const prevHead = () => {
+    if (pageHead - n > 0) {
+      setPage(pageHead - 1);
+      setPageHead(value => value - n);
+    } else {
+      setPage(1);
+      toast('첫 번째 페이지입니다');
+    }
+  };
+  const prevPage = () => {
+    if (page === 1) {
+      toast('첫 번째 페이지입니다');
+    } else {
+      if (page === pageHead) {
+        setPageHead(value => value - n);
+      }
+      setPage(page - 1);
+    }
+  };
+  const nextHead = () => {
+    if (pageHead + n <= total) {
+      setPage(pageHead + n);
+      setPageHead(value => value + n);
+    } else {
+      setPage(total);
+      toast('마지막 페이지입니다');
+    }
+  };
+
+  const nextPage = () => {
+    if (page === total) {
+      toast('마지막 페이지입니다');
+    } else {
+      if (page === pageHead + n - 1) {
+        setPageHead(value => value + n);
+      }
+      setPage(page + 1);
+    }
+  };
+
   return (
     <Wrapper>
-      {Array(total)
+      <Move onClick={prevHead}>{'<<'}</Move>
+      <Move onClick={prevPage}>{'<'}</Move>
+      {pageHead - n > 0 && <More>...</More>}
+      {Array(pageHead + n <= total ? n : total - pageHead + 1)
         .fill(0)
         .map((p, idx) => (
           <Button
-            key={idx + 1}
-            onClick={() => setPage(idx + 1)}
-            isCurrent={page === idx + 1 ? true : false}
+            key={pageHead + idx}
+            onClick={() => setPage(pageHead + idx)}
+            isCurrent={page === pageHead + idx ? true : false}
           >
-            {idx + 1}
+            {pageHead + idx}
           </Button>
         ))}
+      {pageHead + n <= total && <More>...</More>}
+      <Move onClick={nextPage}>{'>'}</Move>
+      <Move onClick={nextHead}>{'>>'}</Move>
     </Wrapper>
   );
 };

--- a/src/pages/market/components/pagination/pagination.styled.tsx
+++ b/src/pages/market/components/pagination/pagination.styled.tsx
@@ -14,6 +14,7 @@ export const Wrapper = styled.div`
   display: flex;
   flex-direction: row;
   align-self: center;
+  align-items: center;
   margin-top: 80px;
   margin-bottom: 60px;
   gap: 16px;
@@ -22,6 +23,20 @@ export const Wrapper = styled.div`
     margin-top: 40px;
     margin-bottom: 40px;
   }
+`;
+
+export const Move = styled.button`
+  width: 36px;
+  height: 24px;
+  border: 0.5px solid gray;
+  border-radius: 12px;
+  background-color: transparent;
+  font-size: 16px;
+  font-weight: 400;
+`;
+
+export const More = styled.span`
+  color: gray;
 `;
 
 export const Button = styled.button<Button>(

--- a/src/pages/market/components/search-bar/index.tsx
+++ b/src/pages/market/components/search-bar/index.tsx
@@ -1,13 +1,15 @@
-import { Wrapper, Bar, Div, Img, Button } from './search-bar.styled';
+import { Wrapper, Bar, Div, Img, Clear } from './search-bar.styled';
 import search from '../../../../assets/search.svg';
+import close from '../../../../assets/close.svg';
 
 interface Search {
   keyword: string;
   setKeyword: React.Dispatch<React.SetStateAction<string>>;
   searchClick: () => void;
+  dong: string | undefined;
 }
 
-const SearchBar = ({ keyword, setKeyword, searchClick }: Search) => {
+const SearchBar = ({ keyword, setKeyword, searchClick, dong }: Search) => {
   const onKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key == 'Enter') {
       searchClick();
@@ -21,11 +23,11 @@ const SearchBar = ({ keyword, setKeyword, searchClick }: Search) => {
         <Bar
           value={keyword}
           onChange={e => setKeyword(e.target.value)}
-          placeholder="봉천동 근처 물품 검색하기"
+          placeholder={`${dong ? dong : '내 동네'} 근처 물품 검색하기`}
           onKeyPress={onKeyPress}
         />
+        {keyword && <Clear src={close} onClick={() => setKeyword('')} />}
       </Div>
-      <Button onClick={searchClick}>검색</Button>
     </Wrapper>
   );
 };

--- a/src/pages/market/components/search-bar/search-bar.styled.tsx
+++ b/src/pages/market/components/search-bar/search-bar.styled.tsx
@@ -19,14 +19,15 @@ export const Wrapper = styled.div`
 export const Div = styled.div`
   display: flex;
   flex-direction: row;
-  width: 400px;
+  width: 430px;
   height: 40px;
   align-items: center;
-  border: 1px solid gray;
+  padding-right: 8px;
+  border: 0.5px solid gray;
   border-radius: 12px;
 
   @media ${MD_SIZE} {
-    width: 98vw;
+    width: 100vw;
     border-left: 0px solid transparent;
     border-radius: 0;
     margin-top: 0;
@@ -45,14 +46,23 @@ export const Img = styled.img`
 `;
 
 export const Bar = styled.input`
-  width: 350px;
+  width: 360px;
   height: 36px;
-  border: 1px solid transparent;
+  border: 0px solid transparent;
   margin-bottom: 1px;
   outline: none;
 
   @media ${MD_SIZE} {
     width: 80%;
+  }
+`;
+
+export const Clear = styled.img`
+  width: 22px;
+  height: 22px;
+  margin-left: auto;
+  @media ${MD_SIZE} {
+  
   }
 `;
 

--- a/src/pages/market/components/search-bar/search-bar.styled.tsx
+++ b/src/pages/market/components/search-bar/search-bar.styled.tsx
@@ -12,6 +12,7 @@ export const Wrapper = styled.div`
     width: 100vw;
     align-items: center;
     margin-top: 0px;
+    margin-bottom: 0px;
     gap: 0;
   }
 `;
@@ -23,12 +24,14 @@ export const Div = styled.div`
   height: 40px;
   align-items: center;
   padding-right: 8px;
-  border: 0.5px solid gray;
+  border: 0.5px solid #8a8a8a;
   border-radius: 12px;
 
   @media ${MD_SIZE} {
     width: 100vw;
     border-left: 0px solid transparent;
+    border-right: 0px solid transparent;
+    border-bottom: 0px solid transparent;
     border-radius: 0;
     margin-top: 0;
   }
@@ -62,7 +65,6 @@ export const Clear = styled.img`
   height: 22px;
   margin-left: auto;
   @media ${MD_SIZE} {
-  
   }
 `;
 

--- a/src/pages/market/components/shortcut/index.tsx
+++ b/src/pages/market/components/shortcut/index.tsx
@@ -15,6 +15,7 @@ import {
 } from './shortcut.styled';
 import TradeStatusButton from '../../../../components/trade-status-button';
 import { TradeStatusType } from '../../../../types/tradePost';
+import { toStringNumWithComma } from '../../../../utils/tradePost';
 import alt from '../../../../assets/post-alt.png';
 
 interface ShortCut {
@@ -56,7 +57,7 @@ const ShortCut = ({
           {tradeStatus !== TradeStatusType.TRADING && (
             <TradeStatusButton tradeStatus={tradeStatus} />
           )}
-          <Price>{price}원</Price>
+          <Price>{toStringNumWithComma(price)}원</Price>
         </PriceBox>
         <Location>{location}</Location>
         <Detail>

--- a/src/pages/market/components/shortcut/shortcut.styled.tsx
+++ b/src/pages/market/components/shortcut/shortcut.styled.tsx
@@ -21,7 +21,7 @@ export const Container = styled.div`
     align-content: center;
     width: 100%;
     height: 180px;
-    border-bottom: 0.5px solid black;
+    border-top: 0.5px solid #8a8a8a;
     border-radius: 0;
     gap: 4px;
   }

--- a/src/pages/market/index.tsx
+++ b/src/pages/market/index.tsx
@@ -16,8 +16,7 @@ import { useAppDispatch, useAppSelector } from '../../store/hooks';
 
 import { redirectWithMsg } from '../../utils/errors';
 import { TradePostType } from '../../types/tradePost';
-import { shortenLocation } from '../../utils/location';
-import { TradeStatusType } from '../../types/tradePost';
+import { shortenLocation, getDong } from '../../utils/location';
 
 import { Wrapper, Header, List } from './market.styled';
 import defaultImg from '../../assets/default-trade-img.svg';
@@ -26,6 +25,8 @@ const MarketPage = () => {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const { accessToken } = useAppSelector(state => state.session);
+  const { me } = useAppSelector(state => state.users);
+  const [dong, setDong] = useState<string>('내 동네');
   const [keyword, setKeyword] = useState<string>('');
   const [data, setData] = useState<TradePostType[]>([]);
   const [totalPage, setTotalPage] = useState<number>(1);
@@ -80,7 +81,7 @@ const MarketPage = () => {
     } else if (Number(values.price) % 10 !== 0) {
       toast.warn('1원 단위는 입력하실 수 없습니다.');
       return;
-    } 
+    }
 
     if (accessToken) {
       dispatch(
@@ -93,7 +94,7 @@ const MarketPage = () => {
         .then(res => {
           setOpenCreatePost(false);
           navigate(`/tradepost/${res.postId}`);
-          toast.success('성공적으로 등록되었습니다.')
+          toast.success('성공적으로 등록되었습니다.');
           setValues({
             title: '',
             desc: '',
@@ -153,8 +154,6 @@ const MarketPage = () => {
             }
           }
         });
-    } else {
-      redirectWithMsg(2, '로그인이 필요합니다', () => navigate('/login'));
     }
   }, [accessToken, page]);
 
@@ -192,6 +191,21 @@ const MarketPage = () => {
         });
     }
   };
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      searchHandler();
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [accessToken, keyword]);
+
+  useEffect(() => {
+    if (me) {
+      setDong(getDong(me.location) as string);
+    }
+  }, [me, accessToken]);
+
   return (
     <>
       <Gnb />
@@ -202,6 +216,7 @@ const MarketPage = () => {
               keyword={keyword}
               setKeyword={setKeyword}
               searchClick={searchHandler}
+              dong={dong}
             />
           </Header>
           <List>

--- a/src/pages/market/market.styled.tsx
+++ b/src/pages/market/market.styled.tsx
@@ -56,6 +56,7 @@ export const List = styled.div`
     column-gap: 0;
     width: 100vw;
     padding: 0;
+    border-bottom: 0.5px solid #8a8a8a;
   }
 
   @media ${Market_MD} {

--- a/src/pages/sell-history-my/components/shortcut/index.tsx
+++ b/src/pages/sell-history-my/components/shortcut/index.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import Moment from 'react-moment';
+import { toStringNumWithComma } from '../../../../utils/tradePost';
 import {
   Container,
   Img,
@@ -65,7 +66,7 @@ const ShortCut = ({
           {tradeStatus !== 'TRADING' && (
             <TradeStatusButton tradeStatus={tradeStatus} />
           )}
-          <Price>{price}원</Price>
+          <Price>{toStringNumWithComma(price)}원</Price>
         </PriceBox>
         <Location>{location}</Location>
         <Detail>

--- a/src/pages/sell-history-my/components/shortcut/shortcut.styled.tsx
+++ b/src/pages/sell-history-my/components/shortcut/shortcut.styled.tsx
@@ -35,6 +35,7 @@ export const Img = styled.img`
   border: 1px solid transparent;
   border-radius: 12px;
   margin-bottom: 4px;
+  object-fit: cover;
 
   @media ${MD_SIZE} {
     width: 160px;

--- a/src/pages/sell-history-my/components/shortcut/shortcut.styled.tsx
+++ b/src/pages/sell-history-my/components/shortcut/shortcut.styled.tsx
@@ -21,8 +21,7 @@ export const Container = styled.div`
     align-content: center;
     width: 100%;
     height: 180px;
-    border-top: 0.5px solid black;
-    border-bottom: 0.5px solid black;
+    border-top: 0.5px solid #8a8a8a;
     border-collapse: collapse;
     border-radius: 0;
     gap: 4px;

--- a/src/pages/sell-history-my/index.tsx
+++ b/src/pages/sell-history-my/index.tsx
@@ -29,9 +29,11 @@ const SellHistoryMyPage = () => {
         .unwrap()
         .then(res => {
           setData(
-            res.posts.filter((post: TradeHistory) => {
-              return post.tradeStatus === status;
-            }),
+            res.posts
+              .filter((post: TradeHistory) => {
+                return post.tradeStatus === status;
+              })
+              .reverse(),
           );
         })
         .catch(err => {

--- a/src/pages/sell-history-my/sell-history-my.styled.tsx
+++ b/src/pages/sell-history-my/sell-history-my.styled.tsx
@@ -18,6 +18,7 @@ export const Header = styled.div`
 
   @media ${MD_SIZE} {
     width: 100vw;
+    margin-top: 20px;
   }
 `;
 
@@ -72,6 +73,7 @@ export const List = styled.div`
     column-gap: 0;
     width: 100vw;
     padding: 0;
+    border-bottom: 0.5px solid #8a8a8a;
   }
 
   @media ${Market_MD} {

--- a/src/pages/sell-history-my/sell-history-my.styled.tsx
+++ b/src/pages/sell-history-my/sell-history-my.styled.tsx
@@ -55,6 +55,8 @@ export const Filter = styled.select`
   width: 160px;
   height: 30px;
   margin-left: auto;
+  border: 0.5px solid #8a8a8a;
+  border-radius: 6px;
 `;
 
 export const Option = styled.option``;

--- a/src/pages/sell-history-others/components/shortcut/index.tsx
+++ b/src/pages/sell-history-others/components/shortcut/index.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import Moment from 'react-moment';
+import { toStringNumWithComma } from '../../../../utils/tradePost';
 import {
   Container,
   Img,
@@ -57,7 +58,7 @@ const ShortCut = ({
           {tradeStatus !== 'TRADING' && (
             <TradeStatusButton tradeStatus={tradeStatus} />
           )}
-          <Price>{price}원</Price>
+          <Price>{toStringNumWithComma(price)}원</Price>
         </PriceBox>
         <Location>{location}</Location>
         <Detail>

--- a/src/pages/sell-history-others/components/shortcut/shortcut.styled.tsx
+++ b/src/pages/sell-history-others/components/shortcut/shortcut.styled.tsx
@@ -21,9 +21,7 @@ export const Container = styled.div`
     align-content: center;
     width: 100%;
     height: 180px;
-    border-top: 0.5px solid black;
-    border-bottom: 0.5px solid black;
-    border-collapse: collapse;
+    border-top: 0.5px solid #8a8a8a;
     border-radius: 0;
     gap: 4px;
   }

--- a/src/pages/sell-history-others/components/shortcut/shortcut.styled.tsx
+++ b/src/pages/sell-history-others/components/shortcut/shortcut.styled.tsx
@@ -35,6 +35,7 @@ export const Img = styled.img`
   border: 1px solid transparent;
   border-radius: 12px;
   margin-bottom: 4px;
+  object-fit: cover;
 
   @media ${MD_SIZE} {
     width: 160px;

--- a/src/pages/sell-history-others/index.tsx
+++ b/src/pages/sell-history-others/index.tsx
@@ -40,9 +40,11 @@ const SellHistoryOthersPage = () => {
       .unwrap()
       .then(res => {
         setData(
-          res.posts.filter((post: TradeHistory) => {
-            return post.tradeStatus === status;
-          }),
+          res.posts
+            .filter((post: TradeHistory) => {
+              return post.tradeStatus === status;
+            })
+            .reverse(),
         );
       })
       .catch(err => {

--- a/src/pages/sell-history-others/sell-history-others.styled.tsx
+++ b/src/pages/sell-history-others/sell-history-others.styled.tsx
@@ -18,6 +18,7 @@ export const Header = styled.div`
 
   @media ${MD_SIZE} {
     width: 100vw;
+    margin-top: 20px;
   }
 `;
 
@@ -72,6 +73,7 @@ export const List = styled.div`
     column-gap: 0;
     width: 100vw;
     padding: 0;
+    border-bottom: 0.5px solid #8a8a8a;
   }
 
   @media ${Market_MD} {

--- a/src/pages/sell-history-others/sell-history-others.styled.tsx
+++ b/src/pages/sell-history-others/sell-history-others.styled.tsx
@@ -55,6 +55,8 @@ export const Filter = styled.select`
   width: 160px;
   height: 30px;
   margin-left: auto;
+  border: 0.5px solid #8a8a8a;
+  border-radius: 6px;
 `;
 
 export const Option = styled.option``;

--- a/src/utils/location.ts
+++ b/src/utils/location.ts
@@ -10,3 +10,12 @@ export const shortenLocation = (fullLocation: string) => {
   const result = arr.slice(0, dongIdx + 1).join(' ');
   return result;
 };
+
+export const getDong = (fullLocation: string) => {
+  const arr = fullLocation.split(' ');
+  for (let i = 0; i < arr.length; i++) {
+    if (arr[i].slice(-1) === '동') {
+      return arr[i];
+    }
+  }
+};

--- a/src/utils/location.ts
+++ b/src/utils/location.ts
@@ -3,11 +3,15 @@ export const shortenLocation = (fullLocation: string) => {
   const arr = fullLocation.split(' ');
   let dongIdx = 0;
   arr.forEach((word, i) => {
-    if (word.slice(-1) === '동') {
+    if (
+      word.slice(-1) === '동' ||
+      word.slice(-1) === '읍' ||
+      word.slice(-1) === '면'
+    ) {
       dongIdx = i;
     }
   });
-  const result = arr.slice(0, dongIdx + 1).join(' ');
+  const result = arr.slice(1, dongIdx + 1).join(' ');
   return result;
 };
 


### PR DESCRIPTION
## 🙌 To Reviewers

- 어제 이야기 나왔던 부분들 위주로 거의 다 수정 / 추가개발 했습니다.
- TODO
- 1. accessToken 만료시 refresh
- 2. 판매내역에 거래 확정 버튼 추가
- 3. 판매, 구매내역 모바일 뷰에 후기 보내기 버튼 추가

<br>

## 🔑 Key Changes

- `검색 방식 변경`:
이제 타이핑을 할 때마다 목록이 업데이트 됩니다. (쓰로틀링 0.3초)
- `검색 placeholder 변경`: 
이제 placeholder에 자신의 동네가 표시됩니다
- `페이지네이션`: 
페이지 버튼이 3개만 보이고 1페이지 / 3페이지씩 이동할 수 있게 버튼을 만들었습니다. (추후에 게시글이 더 많아지면 단위를 3->5로 늘리려고 합니다) + 더 이동할 수 있는 페이지가 있다면 ...이 나타나도록 했습니다.
- `가격 comma`: 
ShortCut의 가격에 3자리 단위마다 콤마 추가했습니다.
- `style`: 
일단 border를 #8a8a8a 색상으로 변경했습니다. (추후 통일 예정)
- `shortenLocation 함수`: 
'동' 단위가 없는 주소의 경우 '읍' 또는 '면'으로 나타나게 했습니다. + 당근마켓처럼 도 단위 이상(서울, 부산광역시, 충청남도 등)은 표시되지 않도록 했습니다.

<br>

## ScreenShot (optional)

<img width="772" alt="image" src="https://user-images.githubusercontent.com/109863663/215018287-e7d44b9c-aab9-46f4-9942-4508a16fb36c.png">

<img width="338" alt="image" src="https://user-images.githubusercontent.com/109863663/215018148-bc3103e6-5296-47f7-8c73-7713c1a45660.png">

<img width="334" alt="image" src="https://user-images.githubusercontent.com/109863663/215018185-5fd90aa0-6afe-4435-b72b-a97e7392b0b2.png">


