### PR TITLE
Feat: 판매내역에서 게시글 수정 / 삭제 / 판매완료로 변경 / 리뷰보내기 연결

### DIFF
--- a/src/pages/sell-history-my/components/delete-modal/delete-modal.styled.tsx
+++ b/src/pages/sell-history-my/components/delete-modal/delete-modal.styled.tsx
@@ -26,6 +26,7 @@ export const FixedWrapper = styled.div`
   top: 0;
   left: 0;
   background-color: transparent;
+  z-index: 1002;
 `;
 
 export const Wrapper = styled.div`
@@ -39,6 +40,7 @@ export const Wrapper = styled.div`
 export const ModalContainer = styled.div`
   display: flex;
   flex-direction: column;
+  position: fixed;
   width: 400px;
   height: 200px;
   margin-bottom: 60px;

--- a/src/pages/sell-history-my/components/delete-modal/delete-modal.styled.tsx
+++ b/src/pages/sell-history-my/components/delete-modal/delete-modal.styled.tsx
@@ -1,0 +1,108 @@
+import styled from 'styled-components';
+
+export const Dim = styled.div`
+  width: 100vw;
+  height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  background-color: #00000072;
+  z-index: 1000;
+  animation: modalBgShow 0.8s;
+  @keyframes modalBgShow {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+`;
+
+export const FixedWrapper = styled.div`
+  width: 100vw;
+  height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  background-color: transparent;
+`;
+
+export const Wrapper = styled.div`
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const ModalContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 400px;
+  height: 200px;
+  margin-bottom: 60px;
+  padding: 32px 36px;
+  gap: 8px;
+  overflow-y: auto;
+  background-color: #fff;
+  border-radius: 15px;
+  z-index: 1001;
+  animation: modalShow 1s;
+  @keyframes modalShow {
+    from {
+      opacity: 0;
+      margin-top: -100px;
+    }
+    to {
+      opacity: 1;
+      margin-top: 0;
+    }
+  }
+  box-shadow: 10px 5px 5px rgba(0, 0, 0, 0.4);
+`;
+
+export const Content = styled.h2`
+  font-size: 20px;
+  font-weight: 500;
+`;
+
+export const Info = styled.span`
+  color: gray;
+  font-size: 16px;
+`;
+
+export const ButtonBox = styled.div`
+  display: flex;
+  flex-direction: row;
+  right: 20px;
+  align-self: center;
+  justify-content: center;
+  align-content: center;
+  margin-top: 24px;
+  gap: 12px;
+`;
+
+export const ConfirmButton = styled.button`
+  background-color: #e78111;
+  color: white;
+  text-align: center;
+  width: 56px;
+  height: 36px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font-size: 16px;
+  font-weight: 500;
+`;
+
+export const CancelButton = styled.button`
+  background-color: #eaebee;
+  color: black;
+  text-align: center;
+  width: 56px;
+  height: 36px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font-size: 16px;
+  font-weight: 500;
+`;

--- a/src/pages/sell-history-my/components/delete-modal/index.tsx
+++ b/src/pages/sell-history-my/components/delete-modal/index.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from 'react';
+import * as S from './delete-modal.styled';
+
+const DeleteModal = ({
+  isDeleteModalOpen,
+  setIsDeleteModalOpen,
+  onDeletePost,
+}: {
+  isDeleteModalOpen: boolean;
+  setIsDeleteModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  onDeletePost: () => void;
+}) => {
+  const modalRef = useRef<any>();
+  const onDelete = () => {
+    onDeletePost();
+    setIsDeleteModalOpen(false);
+    location.reload();
+  };
+  const clickOutside = (e: MouseEvent) => {
+    if (isDeleteModalOpen && !modalRef.current.contains(e.target)) {
+      setIsDeleteModalOpen(false);
+    }
+  };
+  useEffect(() => {
+    if (isDeleteModalOpen) {
+      window.addEventListener('click', clickOutside);
+      return () => {
+        window.removeEventListener('click', clickOutside);
+      };
+    }
+  });
+  return (
+    <S.FixedWrapper>
+      <S.Dim>
+        <S.Wrapper>
+          <S.ModalContainer ref={modalRef}>
+            <S.Content>정말 삭제하시겠습니까?</S.Content>
+            <S.Info>삭제한 게시글은 되돌릴 수 없어요</S.Info>
+            <S.ButtonBox>
+              <S.ConfirmButton onClick={onDelete}>삭제</S.ConfirmButton>
+              <S.CancelButton onClick={() => setIsDeleteModalOpen(false)}>
+                취소
+              </S.CancelButton>
+            </S.ButtonBox>
+          </S.ModalContainer>
+        </S.Wrapper>
+      </S.Dim>
+    </S.FixedWrapper>
+  );
+};
+
+export default DeleteModal;

--- a/src/pages/sell-history-my/components/drop-down/drop-down.styled.tsx
+++ b/src/pages/sell-history-my/components/drop-down/drop-down.styled.tsx
@@ -6,37 +6,11 @@ import {
 } from '../../../../constant/breakpoint';
 import { motion } from 'framer-motion';
 
-// export const Container = styled.div`
-//   display: flex;
-//   flex-direction: column;
-//   background: white;
-//   color: #E78111;
-//   position: absolute;
-//   top: 240px;
-//   right: 0px;
-//   width: 80px;
-//   text-align: center;
-//   border: 1px solid black;
-//   border-radius: 6px;
-//   box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.4);
-
-//   @media ${MD_SIZE} {
-//     top: 48px;
-//     right: 12px;
-//   }
-// `;
-
-// export const Button = styled.button`
-//   line-height: 26px;
-//   font-size: 15px;
-//   font-weight: 500;
-//   border-bottom: 0.3px solid gray;
-// `;
-
 export const Container = styled(motion.div)`
   width: 120px;
-  flex-direction: column;
-  position: relative;
+  position: absolute;
+  top: 240px;
+  right: 4px;
   background-color: transparent;
   box-shadow: 0 4px 10px 0 rgba(0, 0, 0, 0.1);
   border-radius: 8px;

--- a/src/pages/sell-history-my/components/drop-down/drop-down.styled.tsx
+++ b/src/pages/sell-history-my/components/drop-down/drop-down.styled.tsx
@@ -4,20 +4,44 @@ import {
   MD_to_XL_SIZE,
   SM_SIZE,
 } from '../../../../constant/breakpoint';
+import { motion } from 'framer-motion';
 
-export const Container = styled.div`
-  display: flex;
+// export const Container = styled.div`
+//   display: flex;
+//   flex-direction: column;
+//   background: white;
+//   color: #E78111;
+//   position: absolute;
+//   top: 240px;
+//   right: 0px;
+//   width: 80px;
+//   text-align: center;
+//   border: 1px solid black;
+//   border-radius: 6px;
+//   box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.4);
+
+//   @media ${MD_SIZE} {
+//     top: 48px;
+//     right: 12px;
+//   }
+// `;
+
+// export const Button = styled.button`
+//   line-height: 26px;
+//   font-size: 15px;
+//   font-weight: 500;
+//   border-bottom: 0.3px solid gray;
+// `;
+
+export const Container = styled(motion.div)`
+  width: 120px;
   flex-direction: column;
-  background: white;
-  color: #E78111;
-  position: absolute;
-  top: 240px;
-  right: 0px;
-  width: 80px;
-  text-align: center;
-  border: 1px solid black;
-  border-radius: 6px;
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.4);
+  position: relative;
+  background-color: transparent;
+  box-shadow: 0 4px 10px 0 rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  overflow: hidden;
+  background: #fff;
 
   @media ${MD_SIZE} {
     top: 48px;
@@ -25,9 +49,54 @@ export const Container = styled.div`
   }
 `;
 
-export const Button = styled.button`
-  line-height: 26px;
+export const ElemWrapper = styled.div`
+  width: 100%;
+  height: auto;
+  padding: 10px;
+`;
+
+export const Elem = styled.span`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 42px;
+  border-radius: 8px;
+  font-weight: 400;
   font-size: 15px;
-  font-weight: 500;
-  border-bottom: 0.3px solid gray;
+  cursor: pointer;
+  color: #8d8d8d;
+  transition: all 0.2s;
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+
+  &:hover {
+    background: #ececec;
+    color: #212124;
+  }
+`;
+
+export const ElemRed = styled.span`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 42px;
+  border-radius: 8px;
+  font-weight: 400;
+  font-size: 15px;
+  cursor: pointer;
+  color: #ff7171;
+  transition: all 0.2s;
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+
+  &:hover {
+    background: #ececec;
+    color: #212124;
+  }
 `;

--- a/src/pages/sell-history-my/components/drop-down/index.tsx
+++ b/src/pages/sell-history-my/components/drop-down/index.tsx
@@ -9,6 +9,7 @@ const DropDown = ({
   setIsReviewModalOpen,
   tradeStatus,
   onTradeConfirmation,
+  setOpenEditPost,
 }: {
   dropDownRef: any;
   isDropped: boolean;
@@ -17,6 +18,7 @@ const DropDown = ({
   setIsReviewModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
   tradeStatus: string;
   onTradeConfirmation: () => void;
+  setOpenEditPost: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
   const clickOutside = (e: MouseEvent) => {
     if (isDropped && !dropDownRef.current.contains(e.target)) {
@@ -33,7 +35,7 @@ const DropDown = ({
   });
 
   const onConfirmation = () => {
-    console.log('판매완료로 변경')
+    console.log('판매완료로 변경');
     onTradeConfirmation();
     setIsReviewModalOpen(true);
   };
@@ -53,7 +55,7 @@ const DropDown = ({
         {tradeStatus === 'RESERVATION' && (
           <S.Elem onClick={onConfirmation}>판매완료로 변경</S.Elem>
         )}
-        <S.Elem>수정하기</S.Elem>
+        <S.Elem onClick={() => setOpenEditPost(true)}>수정하기</S.Elem>
         <S.ElemRed onClick={() => setIsDeleteModalOpen(true)}>
           삭제하기
         </S.ElemRed>

--- a/src/pages/sell-history-my/components/drop-down/index.tsx
+++ b/src/pages/sell-history-my/components/drop-down/index.tsx
@@ -1,16 +1,22 @@
 import { useEffect } from 'react';
-import { Container, Button } from './drop-down.styled';
+import * as S from './drop-down.styled';
 
 const DropDown = ({
   dropDownRef,
   isDropped,
   setIsDropped,
-  setIsModalOpen,
+  setIsDeleteModalOpen,
+  setIsReviewModalOpen,
+  tradeStatus,
+  onTradeConfirmation,
 }: {
   dropDownRef: any;
   isDropped: boolean;
   setIsDropped: React.Dispatch<React.SetStateAction<boolean>>;
-  setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsDeleteModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsReviewModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  tradeStatus: string;
+  onTradeConfirmation: () => void;
 }) => {
   const clickOutside = (e: MouseEvent) => {
     if (isDropped && !dropDownRef.current.contains(e.target)) {
@@ -26,13 +32,33 @@ const DropDown = ({
     }
   });
 
+  const onConfirmation = () => {
+    console.log('판매완료로 변경')
+    onTradeConfirmation();
+    setIsReviewModalOpen(true);
+  };
+
   // TODO: 상품 수정 및 삭제하기 추가
 
   return (
-    <Container>
-      <Button>수정하기</Button>
-      <Button>삭제하기</Button>
-    </Container>
+    <S.Container
+      initial={isDropped ? 'open' : 'close'}
+      animate={isDropped ? 'open' : 'close'}
+      variants={{
+        open: { height: 'auto' },
+        close: { height: 0 },
+      }}
+    >
+      <S.ElemWrapper>
+        {tradeStatus === 'RESERVATION' && (
+          <S.Elem onClick={onConfirmation}>판매완료로 변경</S.Elem>
+        )}
+        <S.Elem>수정하기</S.Elem>
+        <S.ElemRed onClick={() => setIsDeleteModalOpen(true)}>
+          삭제하기
+        </S.ElemRed>
+      </S.ElemWrapper>
+    </S.Container>
   );
 };
 

--- a/src/pages/sell-history-my/components/review-modal/index.tsx
+++ b/src/pages/sell-history-my/components/review-modal/index.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router';
+import * as S from './review-modal.styled';
+
+const ReviewModal = ({
+  isReviewModalOpen,
+  setIsReviewModalOpen,
+  onTradeConfirm,
+  postId,
+}: {
+  isReviewModalOpen: boolean;
+  setIsReviewModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  onTradeConfirm: () => void;
+  postId: number;
+}) => {
+  const navigate = useNavigate();
+  const modalRef = useRef<any>();
+  const clickOutside = (e: MouseEvent) => {
+    if (isReviewModalOpen && !modalRef.current.contains(e.target)) {
+      setIsReviewModalOpen(false);
+    }
+  };
+  useEffect(() => {
+    if (isReviewModalOpen) {
+      window.addEventListener('click', clickOutside);
+      return () => {
+        window.removeEventListener('click', clickOutside);
+      };
+    }
+  });
+  return (
+    <S.FixedWrapper>
+      <S.Dim>
+        <S.Wrapper>
+          <S.ModalContainer ref={modalRef}>
+            <S.Content>거래가 확정되었습니다!</S.Content>
+            <S.Info>따뜻한 후기로 마음을 전달하세요</S.Info>
+            <S.ButtonBox>
+              <S.ConfirmButton
+                onClick={() => navigate(`/tradepost/${postId}/review`)}
+              >
+                후기 보내기
+              </S.ConfirmButton>
+              <S.CancelButton onClick={() => setIsReviewModalOpen(false)}>
+                취소
+              </S.CancelButton>
+            </S.ButtonBox>
+          </S.ModalContainer>
+        </S.Wrapper>
+      </S.Dim>
+    </S.FixedWrapper>
+  );
+};
+
+export default ReviewModal;

--- a/src/pages/sell-history-my/components/review-modal/review-modal.styled.tsx
+++ b/src/pages/sell-history-my/components/review-modal/review-modal.styled.tsx
@@ -1,8 +1,6 @@
 import styled from 'styled-components';
 
 export const Dim = styled.div`
-  min-width: 360px;
-  min-height: 100%;
   width: 100vw;
   height: 100vh;
   position: fixed;
@@ -28,6 +26,7 @@ export const FixedWrapper = styled.div`
   top: 0;
   left: 0;
   background-color: transparent;
+  z-index: 1002;
 `;
 
 export const Wrapper = styled.div`

--- a/src/pages/sell-history-my/components/review-modal/review-modal.styled.tsx
+++ b/src/pages/sell-history-my/components/review-modal/review-modal.styled.tsx
@@ -1,0 +1,110 @@
+import styled from 'styled-components';
+
+export const Dim = styled.div`
+  min-width: 360px;
+  min-height: 100%;
+  width: 100vw;
+  height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  background-color: #00000072;
+  z-index: 1000;
+  animation: modalBgShow 0.8s;
+  @keyframes modalBgShow {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+`;
+
+export const FixedWrapper = styled.div`
+  width: 100vw;
+  height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  background-color: transparent;
+`;
+
+export const Wrapper = styled.div`
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const ModalContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 400px;
+  height: 200px;
+  margin-bottom: 60px;
+  padding: 40px 42px;
+  gap: 8px;
+  overflow-y: auto;
+  background-color: #fff;
+  border-radius: 15px;
+  z-index: 1001;
+  animation: modalShow 1s;
+  @keyframes modalShow {
+    from {
+      opacity: 0;
+      margin-top: -100px;
+    }
+    to {
+      opacity: 1;
+      margin-top: 0;
+    }
+  }
+  box-shadow: 10px 5px 5px rgba(0, 0, 0, 0.4);
+`;
+
+export const Content = styled.h2`
+  font-size: 20px;
+  font-weight: 500;
+`;
+
+export const Info = styled.span`
+  color: gray;
+  font-size: 16px;
+`;
+
+export const ButtonBox = styled.div`
+  display: flex;
+  flex-direction: row;
+  right: 20px;
+  align-self: center;
+  justify-content: center;
+  align-content: center;
+  margin-top: 24px;
+  gap: 12px;
+`;
+
+export const ConfirmButton = styled.button`
+  background-color: #e78111;
+  color: white;
+  text-align: center;
+  width: 80px;
+  height: 36px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+`;
+
+export const CancelButton = styled.button`
+  background-color: #eaebee;
+  color: black;
+  text-align: center;
+  width: 48px;
+  height: 36px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+`;

--- a/src/pages/sell-history-my/components/shortcut/index.tsx
+++ b/src/pages/sell-history-my/components/shortcut/index.tsx
@@ -1,10 +1,21 @@
 import { useState, useRef } from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
+import axios from 'axios';
+import { toast } from 'react-toastify';
 import Moment from 'react-moment';
 import { toStringNumWithComma } from '../../../../utils/tradePost';
 import {
+  postConfirmation,
+  deleteTradePost,
+} from '../../../../store/slices/tradePostSlice';
+import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
+import { redirectWithMsg } from '../../../../utils/errors';
+import DeleteModal from '../delete-modal';
+import ReviewModal from '../review-modal';
+import {
   Container,
   Img,
+  Div,
   Info,
   Title,
   PriceBox,
@@ -44,11 +55,69 @@ const ShortCut = ({
   chats,
   created_at,
 }: ShortCut) => {
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  const { accessToken } = useAppSelector(state => state.session);
   const [isDropped, setIsDropped] = useState(false);
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [isReviewModalOpen, setIsReviewModalOpen] = useState(false);
   const dropDownRef = useRef<any>();
   const clickDropDown = () => {
     setIsDropped(prev => !prev);
+  };
+  const handleDeletePost = () => {
+    if (accessToken && postId) {
+      dispatch(deleteTradePost({ accessToken: accessToken, postId: postId }))
+        .unwrap()
+        .then(() => {
+          toast.success('성공적으로 삭제되었습니다.');
+        })
+        .catch(err => {
+          if (axios.isAxiosError(err)) {
+            if (err.response?.status === 404) {
+              redirectWithMsg(2, err.response?.data.error, () => navigate(-1));
+            } else if (err.response?.status === 401) {
+              // TODO: refresh 후 재요청
+              redirectWithMsg(2, err.response?.data.error, () =>
+                navigate('/login'),
+              );
+            } else if (err.response?.status === 400) {
+              toast.error(err.response?.data.error);
+            } else {
+              redirectWithMsg(2, '요청을 수행할 수 없습니다.', () =>
+                navigate('/'),
+              );
+            }
+          }
+        });
+    }
+  };
+  const handleTradeConfirmation = () => {
+    if (accessToken && postId) {
+      dispatch(postConfirmation({ accessToken: accessToken, postId: postId }))
+        .unwrap()
+        .then(() => {
+          toast('판매 완료로 변경되었습니다');
+        })
+        .catch(err => {
+          if (axios.isAxiosError(err)) {
+            if (err.response?.status === 404) {
+              redirectWithMsg(2, err.response?.data.error, () => navigate(-1));
+            } else if (err.response?.status === 401) {
+              // TODO: refresh 후 재요청
+              redirectWithMsg(2, err.response?.data.error, () =>
+                navigate('/login'),
+              );
+            } else if (err.response?.status === 400) {
+              toast.error(err.response?.data.error);
+            } else {
+              redirectWithMsg(2, '요청을 수행할 수 없습니다.', () =>
+                navigate('/'),
+              );
+            }
+          }
+        });
+    }
   };
   return (
     <Container>
@@ -58,32 +127,52 @@ const ShortCut = ({
           onError={e => ((e.target as HTMLImageElement).src = alt)}
         />
       </Link>
-      <Info>
-        <Link to={`/tradepost/${postId}`}>
-          <Title>{title}</Title>
-        </Link>
-        <PriceBox>
-          {tradeStatus !== 'TRADING' && (
-            <TradeStatusButton tradeStatus={tradeStatus} />
-          )}
-          <Price>{toStringNumWithComma(price)}원</Price>
-        </PriceBox>
-        <Location>{location}</Location>
-        <Detail>
-          <Likes>관심 {likes} · </Likes>
-          <Chats>채팅 {chats} · </Chats>
-          <Date>
-            <Moment fromNow>{created_at}</Moment>
-          </Date>
-        </Detail>
-      </Info>
-      <More src={more} ref={dropDownRef} onClick={clickDropDown} />
+      <Div>
+        <Info>
+          <Link to={`/tradepost/${postId}`}>
+            <Title>{title}</Title>
+          </Link>
+          <PriceBox>
+            {tradeStatus !== 'TRADING' && (
+              <TradeStatusButton tradeStatus={tradeStatus} />
+            )}
+            <Price>{toStringNumWithComma(price)}원</Price>
+          </PriceBox>
+          <Location>{location}</Location>
+          <Detail>
+            <Likes>관심 {likes} · </Likes>
+            <Chats>채팅 {chats} · </Chats>
+            <Date>
+              <Moment fromNow>{created_at}</Moment>
+            </Date>
+          </Detail>
+        </Info>
+        <More src={more} ref={dropDownRef} onClick={clickDropDown} />
+      </Div>
       {isDropped && (
         <DropDown
           dropDownRef={dropDownRef}
           isDropped={isDropped}
           setIsDropped={setIsDropped}
-          setIsModalOpen={setIsModalOpen}
+          setIsDeleteModalOpen={setIsDeleteModalOpen}
+          setIsReviewModalOpen={setIsReviewModalOpen}
+          tradeStatus={tradeStatus}
+          onTradeConfirmation={handleTradeConfirmation}
+        />
+      )}
+      {isDeleteModalOpen && (
+        <DeleteModal
+          isDeleteModalOpen={isDeleteModalOpen}
+          setIsDeleteModalOpen={setIsDeleteModalOpen}
+          onDeletePost={handleDeletePost}
+        />
+      )}
+      {isReviewModalOpen && (
+        <ReviewModal
+          isReviewModalOpen={isReviewModalOpen}
+          setIsReviewModalOpen={setIsReviewModalOpen}
+          onTradeConfirm={handleTradeConfirmation}
+          postId={postId}
         />
       )}
     </Container>

--- a/src/pages/sell-history-my/components/shortcut/shortcut.styled.tsx
+++ b/src/pages/sell-history-my/components/shortcut/shortcut.styled.tsx
@@ -114,9 +114,10 @@ export const Date = styled.span`
 `;
 
 export const More = styled.img`
-  position: relative;
+  position: absolute;
+  right: 0px;
+  top: 212px;
   width: 20px;
-  height: 20px;
 
   @media ${MD_SIZE} {
     top: 20px;

--- a/src/pages/sell-history-my/components/shortcut/shortcut.styled.tsx
+++ b/src/pages/sell-history-my/components/shortcut/shortcut.styled.tsx
@@ -11,7 +11,7 @@ export const Container = styled.div`
   position: relative;
   width: 200px;
   height: 300px;
-  border: 1px solid white;
+  border: 1px solid transparent;
   border-radius: 12px;
   gap: 4px;
 
@@ -45,14 +45,21 @@ export const Img = styled.img`
   }
 `;
 
+export const Div = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+
 export const Info = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-content: center;
+  width: 180px;
   gap: 6px;
 
   @media ${MD_SIZE} {
+    width: 50vw;
     gap: 10px;
   }
 `;
@@ -107,10 +114,9 @@ export const Date = styled.span`
 `;
 
 export const More = styled.img`
-  position: absolute;
-  right: 0px;
-  top: 212px;
+  position: relative;
   width: 20px;
+  height: 20px;
 
   @media ${MD_SIZE} {
     top: 20px;

--- a/src/pages/sell-history-my/components/trade-post-update/index.tsx
+++ b/src/pages/sell-history-my/components/trade-post-update/index.tsx
@@ -1,0 +1,70 @@
+import { ChangeEvent } from 'react';
+import * as S from './styles';
+
+interface TradePostUpdateProps {
+  values: {
+    title?: string;
+    desc?: string;
+    price?: number;
+  };
+  handleClose: () => void;
+  handleSubmit: () => void;
+  handleChange: (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => void;
+}
+
+const TradePostUpdate = ({
+  values,
+  handleClose,
+  handleSubmit,
+  handleChange,
+}: TradePostUpdateProps) => {
+  return (
+    <S.ModalOuterLayout>
+      <S.ModalLayout>
+        <S.ModalHeader>
+          <S.ModalClose onClick={handleClose}>닫기</S.ModalClose>
+          <S.ModalTitle>중고거래 글 수정</S.ModalTitle>
+          <S.ModalSubmit onClick={handleSubmit}>완료</S.ModalSubmit>
+        </S.ModalHeader>
+        <S.PostTitle
+          placeholder="글제목"
+          required
+          name="title"
+          value={values?.title}
+          type="text"
+          onChange={handleChange}
+        />
+        <S.PostDesc
+          placeholder="봉천동에 올릴 게시글 내용을 작성해주세요. (가품 및 판매 금지 품목은 게시가 제한될 수 있어요.)"
+          required
+          name="desc"
+          value={values?.desc}
+          onChange={handleChange}
+        />
+        <S.PostPriceWrapper>
+          <S.PostPriceUnit>₩</S.PostPriceUnit>
+          <S.PostPrice
+            placeholder="가격 (원)"
+            required
+            name="price"
+            value={values?.price}
+            type="text"
+            onChange={handleChange}
+          />
+        </S.PostPriceWrapper>
+
+        <S.PostAnnounceWrapper>
+          <S.Emphasize>글 작성하기 전에 알려드려요.</S.Emphasize>
+          <S.Announce>허위 매물은 올리실 수 없어요.</S.Announce>
+          <S.Announce>
+            또한, 중고거래 매물 이외의 글은 동네 생활 게시판을 이용해주세요.
+          </S.Announce>
+        </S.PostAnnounceWrapper>
+      </S.ModalLayout>
+    </S.ModalOuterLayout>
+  );
+};
+
+export default TradePostUpdate;

--- a/src/pages/sell-history-my/components/trade-post-update/styles.tsx
+++ b/src/pages/sell-history-my/components/trade-post-update/styles.tsx
@@ -1,0 +1,186 @@
+import styled from 'styled-components';
+
+export const ModalOuterLayout = styled.div`
+  display: flex;
+  width: 100vw;
+  height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  background-color: #00000072;
+  z-index: 1000;
+  align-items: center;
+  justify-content: center;
+  animation: modalBgShow 0.8s;
+  @keyframes modalBgShow {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+`;
+
+export const ModalLayout = styled.div`
+  position: fixed;
+  z-index: 1005;
+  width: 712px;
+  min-width: 360px;
+  height: auto;
+  background: #fff;
+  box-shadow: 6px 6px 20px rgba(0, 0, 0, 0.25);
+  border-radius: 15px;
+  animation: modalShow 0.5s;
+
+  @keyframes modalShow {
+    from {
+      opacity: 0;
+      margin-top: -100px;
+    }
+    to {
+      opacity: 1;
+      margin-top: 0;
+    }
+  }
+`;
+
+export const ModalHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  height: 54px;
+  padding: 0 22px;
+  margin-top: 3px;
+  border-bottom: 0.5px solid #a9a9a9;
+`;
+
+export const ModalTitle = styled.span`
+  font-family: 'Inter';
+  font-weight: 600;
+  font-size: 17px;
+  color: #000000;
+`;
+
+export const ModalClose = styled.button`
+  font-family: 'Inter';
+  font-weight: 500;
+  font-size: 17px;
+  color: #494949;
+  transition: 0.3s all;
+  &:hover {
+    color: #e78111;
+  }
+`;
+
+export const ModalSubmit = styled.button`
+  font-family: 'Inter';
+  font-weight: 600;
+  font-size: 17px;
+  color: #e78111;
+  transition: 0.3s all;
+  &:hover {
+    color: #ff6a00;
+  }
+`;
+
+export const PostTitle = styled.input`
+  font-family: 'Inter';
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  width: 100%;
+  height: 54px;
+  padding: 0 22px;
+  margin-top: 3px;
+  border: none;
+  border-bottom: 0.5px solid #a9a9a9;
+  font-size: 15px;
+  color: #212124;
+
+  &:focus {
+    outline: none;
+  }
+  &::placeholder {
+    color: #a1a1a1;
+  }
+`;
+
+export const PostDesc = styled.textarea`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 350px;
+  flex-grow: 1;
+  padding: 18px 22px;
+  resize: none;
+  font-size: 15px;
+  border: none;
+  outline: none;
+  color: #212124;
+  overflow: auto;
+
+  &::placeholder {
+    color: #a1a1a1;
+  }
+`;
+
+export const PostPriceWrapper = styled.div`
+  width: 100%;
+  height: 54px;
+  display: flex;
+  align-items: center;
+  border-bottom: 0.5px solid #a9a9a9;
+`;
+
+export const PostPriceUnit = styled.span`
+  width: 30px;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  font-weight: 400;
+  font-size: 15px;
+  color: #a2a2a2;
+  padding: 0 22px;
+`;
+
+export const PostPrice = styled.input`
+  font-family: 'Inter';
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  width: auto;
+  height: 100%;
+  padding: 0 22px 0 0;
+  border: none;
+
+  font-size: 15px;
+  color: #212124;
+
+  &:focus {
+    outline: none;
+  }
+  &::placeholder {
+    color: #a1a1a1;
+  }
+`;
+
+export const PostAnnounceWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  padding: 18px 22px;
+  font-family: 'Inter';
+  font-weight: 400;
+  font-size: 14px;
+  display: flex;
+  color: #d27e22;
+`;
+
+export const Emphasize = styled.h5`
+  font-weight: 600;
+`;
+
+export const Announce = styled.h5``;

--- a/src/pages/sell-history-my/index.tsx
+++ b/src/pages/sell-history-my/index.tsx
@@ -82,6 +82,7 @@ const SellHistoryMyPage = () => {
                 likes={post?.likeCount}
                 chats={post?.reservationCount}
                 created_at={post?.createdAt}
+                desc={post?.desc}
               />
             );
           })}

--- a/src/pages/sell-history-my/index.tsx
+++ b/src/pages/sell-history-my/index.tsx
@@ -5,6 +5,7 @@ import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import Gnb from '../../components/gnb';
 import ShortCut from './components/shortcut';
 import { getSellHistory } from '../../store/slices/tradeHistorySlice';
+import { postConfirmation } from '../../store/slices/tradePostSlice';
 import { shortenLocation } from '../../utils/location';
 import { TradeHistory } from '../../types/history';
 import { redirectWithMsg } from '../../utils/errors';


### PR DESCRIPTION
## 🙌 To Reviewers

- 판매내역 페이지에서 { 게시글을 수정 / 삭제 / 판매완료로 변경 / 리뷰 보내기 페이지로 이동 } 이 가능해졌습니다.
- 예약중인 상품은 드랍다운에 `판매완료로 변경` 항목이 표시되고 판매중 / 판매완료일 경우에는 수정 / 삭제만 뜹니다
- 판매완료이면서 리뷰를 안 보낸 경우에는 리뷰 보내기 항목도 추가할 예정입니다.
- 게시글 수정 부분은 이미지 업로드 부분 반영된 새로운 코드 받아서 수정하도록 하겠습니다.
- 그리고 리뷰는 이전까지는 포스트 데이터에 review가 없어서 판매자가 리뷰를 남기려고 하면 스스로에게 보내는 기괴한 상황이 펼쳐지는데 이것도 코드 최신화해서 다음 pr에서 반영하겠습니다.

<br>

## 🔑 Key Changes

- 판매내역 페이지에서 { 게시글을 수정 / 삭제 / 판매완료로 변경 / 리뷰 보내기 페이지로 이동 }  가능

<br>

## ScreenShot (optional)

https://user-images.githubusercontent.com/109863663/215331189-00359a1e-51e6-444f-a989-4d7f2baa8199.mov

