### PR TITLE
Feat: 판매/구매내역에서 리뷰 보내기 (안 보냈을 경우에만 버튼 뜨기)

### DIFF
--- a/src/pages/buy-history/components/drop-down/drop-down.styled.tsx
+++ b/src/pages/buy-history/components/drop-down/drop-down.styled.tsx
@@ -4,20 +4,18 @@ import {
   MD_to_XL_SIZE,
   SM_SIZE,
 } from '../../../../constant/breakpoint';
+import { motion } from 'framer-motion';
 
-export const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  background: white;
-  color: #E78111;
+export const Container = styled(motion.div)`
+  width: 120px;
   position: absolute;
   top: 240px;
-  right: 0px;
-  width: 90px;
-  text-align: center;
-  border: 1px solid black;
-  border-radius: 6px;
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.4);
+  right: 4px;
+  background-color: transparent;
+  box-shadow: 0 4px 10px 0 rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  overflow: hidden;
+  background: #fff;
 
   @media ${MD_SIZE} {
     top: 48px;
@@ -25,9 +23,54 @@ export const Container = styled.div`
   }
 `;
 
-export const Button = styled.button`
-  line-height: 26px;
+export const ElemWrapper = styled.div`
+  width: 100%;
+  height: auto;
+  padding: 10px;
+`;
+
+export const Elem = styled.span`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 42px;
+  border-radius: 8px;
+  font-weight: 400;
   font-size: 15px;
-  font-weight: 500;
-  border-bottom: 0.3px solid gray;
+  cursor: pointer;
+  color: #8d8d8d;
+  transition: all 0.2s;
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+
+  &:hover {
+    background: #ececec;
+    color: #212124;
+  }
+`;
+
+export const ElemRed = styled.span`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 42px;
+  border-radius: 8px;
+  font-weight: 400;
+  font-size: 15px;
+  cursor: pointer;
+  color: #ff7171;
+  transition: all 0.2s;
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+
+  &:hover {
+    background: #ececec;
+    color: #212124;
+  }
 `;

--- a/src/pages/buy-history/components/drop-down/index.tsx
+++ b/src/pages/buy-history/components/drop-down/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router';
-import { Container, Button } from './drop-down.styled';
+import * as S from './drop-down.styled';
 
 const DropDown = ({
   dropDownRef,
@@ -28,14 +28,21 @@ const DropDown = ({
     }
   });
 
-  // TODO: 이미 리뷰 보낸 경우 처리
-
   return (
-    <Container>
-      <Button onClick={() => navigate(`/tradepost/${postId}/review`)}>
-        리뷰 보내기
-      </Button>
-    </Container>
+    <S.Container
+      initial={isDropped ? 'open' : 'close'}
+      animate={isDropped ? 'open' : 'close'}
+      variants={{
+        open: { height: 'auto' },
+        close: { height: 0 },
+      }}
+    >
+      <S.ElemWrapper>
+        <S.Elem onClick={() => navigate(`/tradepost/${postId}/review`)}>
+          후기 보내기
+        </S.Elem>
+      </S.ElemWrapper>
+    </S.Container>
   );
 };
 

--- a/src/pages/buy-history/components/shortcut/index.tsx
+++ b/src/pages/buy-history/components/shortcut/index.tsx
@@ -20,6 +20,7 @@ import TradeStatusButton from '../../../../components/trade-status-button';
 import DropDown from '../drop-down';
 import alt from '../../../../assets/post-alt.png';
 import more from '../../../../assets/more.svg';
+import { ReviewHistory } from '../../../../types/review';
 
 interface ShortCut {
   postId: number;
@@ -31,6 +32,7 @@ interface ShortCut {
   likes: number;
   chats: number;
   created_at: Date;
+  reviews: ReviewHistory[];
 }
 
 const ShortCut = ({
@@ -43,12 +45,26 @@ const ShortCut = ({
   likes,
   chats,
   created_at,
+  reviews,
 }: ShortCut) => {
   const [isDropped, setIsDropped] = useState(false);
   const dropDownRef = useRef<any>();
   const clickDropDown = () => {
     setIsDropped(prev => !prev);
   };
+  const checkIsReviewed = () => {
+    if (reviews[0]) {
+      for (let i = 0; i < reviews.length; i++) {
+        if (reviews[i].type === 'BUYER') {
+          return true;
+        } else {
+          return false;
+        }
+      }
+    }
+    return false;
+  };
+  const isReviewed = checkIsReviewed();
   return (
     <Container>
       <Link to={`/tradepost/${postId}`}>
@@ -76,7 +92,9 @@ const ShortCut = ({
           </Date>
         </Detail>
       </Info>
-      <More src={more} ref={dropDownRef} onClick={clickDropDown} />
+      {!isReviewed && (
+        <More src={more} ref={dropDownRef} onClick={clickDropDown} />
+      )}
       {isDropped && (
         <DropDown
           dropDownRef={dropDownRef}

--- a/src/pages/buy-history/index.tsx
+++ b/src/pages/buy-history/index.tsx
@@ -62,6 +62,7 @@ const BuyHistoryPage = () => {
                 likes={post?.likeCount}
                 chats={post?.reservationCount}
                 created_at={post?.createdAt}
+                reviews={post?.reviews}
               />
             );
           })}

--- a/src/pages/my-review/components/review-info/index.tsx
+++ b/src/pages/my-review/components/review-info/index.tsx
@@ -15,7 +15,7 @@ import {
 } from './review-info.styled';
 import DropDown from '../drop-down';
 import DeleteModal from '../delete-modal';
-import userImg from '../../../../assets/profile.svg';
+import userImg from '../../../../assets/default-profile.png';
 import more from '../../../../assets/more.svg';
 
 interface ReviewInfo {
@@ -66,7 +66,7 @@ const ReviewInfo = ({
         </Desc>
         <Content>{content}</Content>
       </Info>
-      <More src={more} ref={dropDownRef} onClick={() => setIsDropped(true)} />
+      {/* <More src={more} ref={dropDownRef} onClick={() => setIsDropped(true)} />
       {isDropped && (
         <DropDown
           dropDownRef={dropDownRef}
@@ -81,7 +81,7 @@ const ReviewInfo = ({
           setIsModalOpen={setIsModalOpen}
           deleteReview={deleteReview}
         />
-      )}
+      )} */}
     </Container>
   );
 };

--- a/src/pages/my-review/components/review-info/review-info.styled.tsx
+++ b/src/pages/my-review/components/review-info/review-info.styled.tsx
@@ -8,10 +8,11 @@ export const Container = styled.div`
   width: 100%;
   height: 160px;
   border: 0.5px solid gray;
-  border-radius: 6px;
-  box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.1);
+  border-radius: 12px;
+  box-shadow: 3px 0px 5px rgba(0, 0, 0, 0.1);
   padding: 0 20px;
   gap: 30px;
+  margin-bottom: 16px;
 `;
 
 export const Img = styled.img`

--- a/src/pages/others-review/components/delete-modal/delete-modal.styled.tsx
+++ b/src/pages/others-review/components/delete-modal/delete-modal.styled.tsx
@@ -25,12 +25,15 @@ export const FixedWrapper = styled.div`
   width: 100vw;
   height: 100vh;
   position: fixed;
+  z-index: 1001;
   top: 0;
   left: 0;
   background-color: transparent;
 `;
 
 export const Wrapper = styled.div`
+  position: fixed;
+  z-index: 1001;
   width: 100vw;
   height: 100vh;
   display: flex;
@@ -39,6 +42,7 @@ export const Wrapper = styled.div`
 `;
 
 export const ModalContainer = styled.div`
+  position: fixed;
   display: flex;
   flex-direction: column;
   width: 400px;

--- a/src/pages/others-review/components/review-info/index.tsx
+++ b/src/pages/others-review/components/review-info/index.tsx
@@ -15,7 +15,7 @@ import {
 } from './review-info.styled';
 import DropDown from '../drop-down';
 import DeleteModal from '../delete-modal';
-import userImg from '../../../../assets/profile.svg';
+import userImg from '../../../../assets/default-profile.png';
 import more from '../../../../assets/more.svg';
 
 interface ReviewInfo {

--- a/src/pages/others-review/components/review-info/review-info.styled.tsx
+++ b/src/pages/others-review/components/review-info/review-info.styled.tsx
@@ -8,10 +8,11 @@ export const Container = styled.div`
   width: 100%;
   height: 160px;
   border: 0.5px solid gray;
-  border-radius: 6px;
-  box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.1);
+  border-radius: 12px;
+  box-shadow: 3px 0px 5px rgba(0, 0, 0, 0.1);
   padding: 0 20px;
   gap: 30px;
+  margin-bottom: 16px;
 `;
 
 export const Img = styled.img`

--- a/src/pages/sell-history-my/components/drop-down/index.tsx
+++ b/src/pages/sell-history-my/components/drop-down/index.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router';
 import * as S from './drop-down.styled';
 
 const DropDown = ({
+  postId,
   dropDownRef,
   isDropped,
   setIsDropped,
@@ -10,7 +12,9 @@ const DropDown = ({
   tradeStatus,
   onTradeConfirmation,
   setOpenEditPost,
+  isReviewed,
 }: {
+  postId: number;
   dropDownRef: any;
   isDropped: boolean;
   setIsDropped: React.Dispatch<React.SetStateAction<boolean>>;
@@ -19,7 +23,9 @@ const DropDown = ({
   tradeStatus: string;
   onTradeConfirmation: () => void;
   setOpenEditPost: React.Dispatch<React.SetStateAction<boolean>>;
+  isReviewed: boolean;
 }) => {
+  const navigate = useNavigate();
   const clickOutside = (e: MouseEvent) => {
     if (isDropped && !dropDownRef.current.contains(e.target)) {
       setIsDropped(false);
@@ -54,6 +60,11 @@ const DropDown = ({
       <S.ElemWrapper>
         {tradeStatus === 'RESERVATION' && (
           <S.Elem onClick={onConfirmation}>판매완료로 변경</S.Elem>
+        )}
+        {tradeStatus === 'COMPLETED' && !isReviewed && (
+          <S.Elem onClick={() => navigate(`/tradepost/${postId}/review`)}>
+            후기 보내기
+          </S.Elem>
         )}
         <S.Elem onClick={() => setOpenEditPost(true)}>수정하기</S.Elem>
         <S.ElemRed onClick={() => setIsDeleteModalOpen(true)}>

--- a/src/pages/sell-history-my/components/shortcut/index.tsx
+++ b/src/pages/sell-history-my/components/shortcut/index.tsx
@@ -45,6 +45,7 @@ interface ShortCut {
   chats: number;
   created_at: Date;
   desc: string;
+  getList: () => void;
 }
 
 const ShortCut = ({
@@ -58,6 +59,7 @@ const ShortCut = ({
   chats,
   created_at,
   desc,
+  getList,
 }: ShortCut) => {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
@@ -75,6 +77,7 @@ const ShortCut = ({
         .unwrap()
         .then(() => {
           toast.success('성공적으로 삭제되었습니다.');
+          getList();
         })
         .catch(err => {
           if (axios.isAxiosError(err)) {
@@ -124,11 +127,10 @@ const ShortCut = ({
     }
   };
 
-  // 글 수정
+  // 글 수정 🚀🚀🚀
   const [active, setActive] = useState(false);
-  const [openEditPost, setOpenEditPost] = useState(false);
-  const [openEditPostImg, setOpenEditPostImg] = useState(false);
   const [openDelete, setOpenDelete] = useState(false);
+  const [openEditPost, setOpenEditPost] = useState(false);
 
   const [values, setValues] = useState({
     title: title,
@@ -178,12 +180,14 @@ const ShortCut = ({
           title: values.title,
           desc: values.desc,
           price: values.price,
+          imgs,
         }),
       )
         .unwrap()
         .then(() => {
           setOpenEditPost(false);
           toast.success('성공적으로 수정되었습니다.');
+          getList();
         })
         .catch(err => {
           if (axios.isAxiosError(err)) {
@@ -210,6 +214,9 @@ const ShortCut = ({
       price: price,
     });
   }, []);
+
+  // 사진
+  const [imgs, setImgs] = useState<any>([]);
 
   return (
     <Container>
@@ -255,6 +262,8 @@ const ShortCut = ({
       )}
       {openEditPost && (
         <TradePostUpdate
+          imgs={imgs}
+          setImgs={setImgs}
           values={values}
           handleChange={handleChange}
           handleSubmit={handleSubmitEdit}

--- a/src/pages/sell-history-my/components/shortcut/index.tsx
+++ b/src/pages/sell-history-my/components/shortcut/index.tsx
@@ -33,6 +33,7 @@ import TradeStatusButton from '../../../../components/trade-status-button';
 import DropDown from '../drop-down';
 import alt from '../../../../assets/post-alt.png';
 import more from '../../../../assets/more.svg';
+import { ReviewHistory } from '../../../../types/review';
 
 interface ShortCut {
   postId: number;
@@ -45,6 +46,7 @@ interface ShortCut {
   chats: number;
   created_at: Date;
   desc: string;
+  reviews: ReviewHistory[];
   getList: () => void;
 }
 
@@ -60,6 +62,7 @@ const ShortCut = ({
   created_at,
   desc,
   getList,
+  reviews,
 }: ShortCut) => {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
@@ -71,6 +74,21 @@ const ShortCut = ({
   const clickDropDown = () => {
     setIsDropped(prev => !prev);
   };
+
+  const checkIsReviewed = () => {
+    if (reviews[0]) {
+      for (let i = 0; i < reviews.length; i++) {
+        if (reviews[i].type === 'SELLER') {
+          return true;
+        } else {
+          return false;
+        }
+      }
+    }
+    return false;
+  };
+  const isReviewed = checkIsReviewed();
+
   const handleDeletePost = () => {
     if (accessToken && postId) {
       dispatch(deleteTradePost({ accessToken: accessToken, postId: postId }))
@@ -250,6 +268,7 @@ const ShortCut = ({
       </Div>
       {isDropped && (
         <DropDown
+          postId={postId}
           dropDownRef={dropDownRef}
           isDropped={isDropped}
           setIsDropped={setIsDropped}
@@ -258,6 +277,7 @@ const ShortCut = ({
           tradeStatus={tradeStatus}
           onTradeConfirmation={handleTradeConfirmation}
           setOpenEditPost={setOpenEditPost}
+          isReviewed={isReviewed}
         />
       )}
       {openEditPost && (

--- a/src/pages/sell-history-my/components/trade-post-update/index.tsx
+++ b/src/pages/sell-history-my/components/trade-post-update/index.tsx
@@ -1,4 +1,5 @@
 import { ChangeEvent } from 'react';
+import UploadImage from '../../../../components/upload-image';
 import * as S from './styles';
 
 interface TradePostUpdateProps {
@@ -12,6 +13,8 @@ interface TradePostUpdateProps {
   handleChange: (
     e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => void;
+  imgs: any[];
+  setImgs: any;
 }
 
 const TradePostUpdate = ({
@@ -19,6 +22,8 @@ const TradePostUpdate = ({
   handleClose,
   handleSubmit,
   handleChange,
+  imgs,
+  setImgs,
 }: TradePostUpdateProps) => {
   return (
     <S.ModalOuterLayout>
@@ -43,6 +48,9 @@ const TradePostUpdate = ({
           value={values?.desc}
           onChange={handleChange}
         />
+
+        <UploadImage imgs={imgs} setImgs={setImgs} />
+
         <S.PostPriceWrapper>
           <S.PostPriceUnit>₩</S.PostPriceUnit>
           <S.PostPrice

--- a/src/pages/sell-history-my/index.tsx
+++ b/src/pages/sell-history-my/index.tsx
@@ -29,6 +29,7 @@ const SellHistoryMyPage = () => {
       )
         .unwrap()
         .then(res => {
+          console.log(res);
           setData(
             res.posts
               .filter((post: TradeHistory) => {
@@ -86,6 +87,7 @@ const SellHistoryMyPage = () => {
                 chats={post?.reservationCount}
                 created_at={post?.createdAt}
                 desc={post?.desc}
+                reviews={post?.reviews}
                 getList={getList}
               />
             );

--- a/src/pages/sell-history-my/index.tsx
+++ b/src/pages/sell-history-my/index.tsx
@@ -19,7 +19,7 @@ const SellHistoryMyPage = () => {
   const { me } = useAppSelector(state => state.users);
   const [data, setData] = useState<TradeHistory[]>([]);
   const [status, setStatus] = useState<string>('TRADING');
-  useEffect(() => {
+  const getList = () => {
     if (me) {
       dispatch(
         getSellHistory({
@@ -54,6 +54,9 @@ const SellHistoryMyPage = () => {
           }
         });
     }
+  };
+  useEffect(() => {
+    getList();
   }, [accessToken, me, status]);
 
   return (
@@ -83,6 +86,7 @@ const SellHistoryMyPage = () => {
                 chats={post?.reservationCount}
                 created_at={post?.createdAt}
                 desc={post?.desc}
+                getList={getList}
               />
             );
           })}

--- a/src/pages/sendReview/index.tsx
+++ b/src/pages/sendReview/index.tsx
@@ -69,8 +69,6 @@ const SendReview = () => {
       dispatch(getTradePost({ accessToken: accessToken, postId: postId }))
         .unwrap()
         .then(res => {
-          console.log(me);
-          console.log(res);
           setTradeInfo({
             title: res?.title,
             img: res?.imageUrls[0],

--- a/src/pages/sendReview/index.tsx
+++ b/src/pages/sendReview/index.tsx
@@ -65,15 +65,23 @@ const SendReview = () => {
   });
   const [isValidPage, setIsValidPage] = useState(true);
   useEffect(() => {
-    if (accessToken && postId) {
+    if (accessToken && me && postId) {
       dispatch(getTradePost({ accessToken: accessToken, postId: postId }))
         .unwrap()
         .then(res => {
+          console.log(me);
+          console.log(res);
           setTradeInfo({
             title: res?.title,
             img: res?.imageUrls[0],
-            neighbor: res?.seller.username,
-            neighborId: res?.seller.id,
+            neighbor:
+              me.id === res?.seller.id
+                ? (res?.buyer as any).username
+                : res?.seller.username,
+            neighborId:
+              me.id === res?.seller.id
+                ? (res?.buyer as any).id
+                : res?.seller.id,
           });
         })
         .catch(() => {

--- a/src/store/slices/reviewSlice.ts
+++ b/src/store/slices/reviewSlice.ts
@@ -17,7 +17,7 @@ export const postReview = createAsyncThunk(
   ) => {
     try {
       const res = await axios.post(
-        `${BASE_URL}:81/tradepost/${postId}/review`,
+        `${BASE_URL}/tradepost/${postId}/review`,
         { score: score, content: content },
         { headers: auth(accessToken) },
       );
@@ -32,7 +32,7 @@ export const getReviews = createAsyncThunk(
   'tradePost/getReview',
   async (userId: number, { rejectWithValue }) => {
     try {
-      const res = await axios.get(`${BASE_URL}:81/users/${userId}/reviews`);
+      const res = await axios.get(`${BASE_URL}/users/${userId}/reviews`);
       return res.data;
     } catch (err) {
       return rejectWithValue(err);

--- a/src/types/history.ts
+++ b/src/types/history.ts
@@ -1,5 +1,6 @@
 import { User } from './users';
 import { TradeStatusType } from './tradePost';
+import { ReviewHistory } from './review';
 
 export type TradeHistory = {
   postId: number;
@@ -17,4 +18,5 @@ export type TradeHistory = {
   isOwner: boolean;
   createdAt: Date;
   modifiedAt: Date;
+  reviews: ReviewHistory[];
 };

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -18,3 +18,10 @@ export type Review = {
   content: string;
   type: BuySellType;
 };
+
+export type ReviewHistory = {
+  id: number;
+  type: BuySellType;
+  createdAt: Date;
+  content: string;
+};

--- a/src/types/tradePost.ts
+++ b/src/types/tradePost.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // TODO: 백엔드와 타입 합의 후 타입정보 수정
 
+import { ReviewHistory } from "./review";
+
 export enum TradeStatusType {
   TRADING = 'TRADING',
   RESERVATION = 'RESERVATION',
@@ -27,6 +29,7 @@ export type TradePostType = {
   // 🥕 later...
   otherPosts: any;
   imageUrls?: any;
+  reviews: ReviewHistory[]
 };
 
 export type TxUser = {


### PR DESCRIPTION
## 🙌 To Reviewers

- tradePost 데이터에 reviews 필드가 추가되면서 유저가 특정 상품에 대한 후기를 보냈는지 여부를 판단할 수 있게 되었고, 리뷰를 보내지 않은 상품에만 리뷰 보내기 버튼이 뜨도록 작업했습니다.
- 저번 회의 때 나왔던 '드랍다운을 통한 후기 보내기 방식이 직관적이지 않다'는 피드백에 따라 디자인 수정을 좀 해보려고 합니다..! 곧 작업해서 올리겠습니다.
- 이 플로우대로 채팅방 작업도 진행중이니 얼른 해서 올리겠습니다

<br>

## 🔑 Key Changes

- 판매목록에서 거래완료 & 후기를 보내지 않은 경우에만 드랍다운에 후기 보내기 항목이 뜸
- 구매목록에서도 마찬가지

<br>

## ScreenShot (optional)

https://user-images.githubusercontent.com/109863663/215370783-71152dc3-a79e-4485-a211-db8ff2af9132.mov

