### PR TITLE
feat: 액세스 토큰 만료 전 재발급

### DIFF
--- a/src/components/gnb/index.tsx
+++ b/src/components/gnb/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import Drawer from '../drawer';
@@ -31,7 +31,7 @@ const Gnb = ({ isColored }: GnbProps) => {
   const dispatch = useAppDispatch();
   const { active, handleToggleDrawer } = useDrawer();
   const { me } = useAppSelector(state => state.users);
-  const { accessToken } = useAppSelector(state => state.session);
+  const { accessToken, expiryTime } = useAppSelector(state => state.session);
 
   const [selected, setSelected] = useState({
     intro: false,
@@ -47,17 +47,39 @@ const Gnb = ({ isColored }: GnbProps) => {
   }, [me]);
 
   useEffect(() => {
-    if (accessToken) {
-      dispatch(getMe(accessToken));
-    } else {
-      const refreshToken = loadItem('refreshToken');
+    const refreshToken = loadItem('refreshToken');
+    if (!accessToken || !expiryTime) {
       if (refreshToken) {
-        dispatch(postRefresh(refreshToken))
+        dispatch(postRefresh(refreshToken as string))
           .unwrap()
           .then(res => dispatch(getMe(res.accessToken)));
       }
+    } else {
+      if (refreshToken) {
+        dispatch(getMe(accessToken));
+      }
     }
-  }, [accessToken]);
+  }, [accessToken, expiryTime]);
+
+  // DESC: 토큰 만료시간 1분 전에 refresh
+  useEffect(() => {
+    const refreshToken = loadItem('refreshToken');
+    if (refreshToken) {
+      const refreshSession = () => {
+        dispatch(postRefresh(refreshToken as string))
+          .unwrap()
+          .then(res => {
+            // console.log('refresh!!!', res);
+            dispatch(getMe(res.accessToken));
+          });
+      };
+      const timeout = setTimeout(
+        refreshSession,
+        expiryTime - Date.now() - 60 * 1000,
+      );
+      return () => clearTimeout(timeout);
+    }
+  }, [accessToken, expiryTime]);
 
   useEffect(() => {
     switch (pathname) {
@@ -82,6 +104,20 @@ const Gnb = ({ isColored }: GnbProps) => {
     dispatch(sessionActions.logout());
     window.location.href = '/';
   }, []);
+
+  // 임시: 토큰 만료 전 refresh 확인용
+  const [minute, setMinute] = useState<any>();
+  const [second, setSecond] = useState<any>();
+  const interval = useRef(null);
+  useEffect(() => {
+    // console.log(new Date(expiryTime));
+    // console.log(accessToken);
+    (interval.current as any) = setInterval(() => {
+      setMinute(new Date(expiryTime - Date.now()).getMinutes());
+      setSecond(new Date(expiryTime - Date.now()).getSeconds());
+    }, 1000);
+    return () => clearInterval(interval.current as any);
+  }, [expiryTime]);
 
   return (
     <S.Wrapper isColored={isColored}>
@@ -112,7 +148,11 @@ const Gnb = ({ isColored }: GnbProps) => {
                 로그인
               </S.Auth>
             )}
-
+            {accessToken && (
+              <span>
+                남은시간= {minute}:{second}
+              </span>
+            )}
             <Footer />
           </>
         </Drawer>

--- a/src/pages/market/index.tsx
+++ b/src/pages/market/index.tsx
@@ -21,6 +21,7 @@ import { shortenLocation, getDong } from '../../utils/location';
 
 import { Wrapper, Header, List } from './market.styled';
 import defaultImg from '../../assets/default-trade-img.svg';
+import { loadItem } from '../../utils/storage';
 
 const MarketPage = () => {
   const navigate = useNavigate();

--- a/src/store/slices/sessionSlice.ts
+++ b/src/store/slices/sessionSlice.ts
@@ -101,7 +101,6 @@ export const sessionSlice = createSlice({
     logout: state => {
       state.accessToken = null;
       clearItem('refreshToken');
-      clearItem('isAuthed');
     },
   },
   extraReducers: builder => {


### PR DESCRIPTION
## 🙌 To Reviewers

- 액세스 토큰 유효기간이 1시간인데, 만료까지 1분 남았을 때 연장해주는 부분 구현했습니다.
- 로그인할 때, 액세스 토큰 재발급 할 때 expiryTime을 지금으로부터 60분 뒤로 잡고, gnb에서 setTimeout으로 59분 뒤에 세션 연장하도록 했습니다.
- gnb drawer에 테스트용으로 남은 세션 시간 뜨도록 했는데 (수강신청 페이지처럼) 테스트 몇번 잘 되면 지우도록 할게요
- 진짜 별 내용은 없네요.. 토큰쪽 공부하는 시간이 길었습니다.. 저희 학습속도...

<br>

## 🔑 Key Changes

- 세션 만료 전 로그인 연장

<br>

## ScreenShot (optional)

-
