### PR TITLE
Feat: axios interceptor로 만료된 토큰일 경우 요청 올바르게 처리

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,6 +1,10 @@
 import axios, { AxiosResponse } from 'axios';
+import { redirect, useNavigate } from 'react-router';
 import { BASE_URL } from '../constant';
+import { useAppDispatch } from '../store/hooks';
+import { postRefresh } from '../store/slices/sessionSlice';
 import { loadItem } from '../utils/storage';
+import { redirectWithMsg } from '../utils/errors';
 
 // DESC: api util 관련 함수 모음
 export const url = (path: string, param?: Record<string, string>) =>
@@ -30,6 +34,43 @@ axiosApiInstance.interceptors.response.use(
 
         originalRequest.headers.Authorization = `Bearer ${res.data.accessToken}`;
         return axios(originalRequest);
+      }
+    }
+    return Promise.reject(error);
+  },
+);
+
+// DESC: 22.02.01 interceptor for 401
+
+export const axiosI = axios.create({
+  baseURL: BASE_URL,
+});
+
+axiosI.interceptors.response.use(
+  (response: AxiosResponse) => response,
+  async (error: any) => {
+    const originalRequest = error.cofig;
+
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      const dispatch = useAppDispatch();
+      const navigate = useNavigate();
+      const refreshToken = loadItem('refreshToken');
+
+      try {
+        if (refreshToken) {
+          await dispatch(postRefresh(refreshToken));
+          const newToken = loadItem('accessToken');
+          const authNewToken = auth(newToken as string).Authorization;
+          axiosI.defaults.headers.common.Authorization = authNewToken;
+          originalRequest.headers.Authorization = authNewToken;
+          return axiosI(originalRequest);
+        } else {
+          redirectWithMsg(1, '로그인이 필요합니다', () => navigate('/login'));
+        }
+      } catch (e) {
+        return Promise.reject(e);
       }
     }
     return Promise.reject(error);

--- a/src/store/slices/marketSlice.ts
+++ b/src/store/slices/marketSlice.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 
 import { auth } from '../../api';
+import { axiosI } from '../../api';
 import { BASE_URL } from '../../constant';
 import { TradePostResponse } from '../../types/market';
 
@@ -17,8 +18,8 @@ export const getTradePostList = createAsyncThunk(
     { rejectWithValue },
   ) => {
     try {
-      const res = await axios.get<TradePostResponse>(
-        `${BASE_URL}/tradepost?keyword=${keyword}&page=${page}&limit=${limit}`,
+      const res = await axiosI.get<TradePostResponse>(
+        `/tradepost?keyword=${keyword}&page=${page}&limit=${limit}`,
         { headers: auth(accessToken) },
       );
       return res.data;

--- a/src/store/slices/reviewSlice.ts
+++ b/src/store/slices/reviewSlice.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 
 import { auth } from '../../api';
+import { axiosI } from '../../api';
 import { BASE_URL } from '../../constant';
 
 export const postReview = createAsyncThunk(
@@ -16,8 +17,8 @@ export const postReview = createAsyncThunk(
     { rejectWithValue },
   ) => {
     try {
-      const res = await axios.post(
-        `${BASE_URL}/tradepost/${postId}/review`,
+      const res = await axiosI.post(
+        `/tradepost/${postId}/review`,
         { score: score, content: content },
         { headers: auth(accessToken) },
       );

--- a/src/store/slices/tradePostSlice.ts
+++ b/src/store/slices/tradePostSlice.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 
 import { auth } from '../../api';
+import { axiosI } from '../../api';
 import { BASE_URL } from '../../constant';
 import { TradePostType, TxUser } from '../../types/tradePost';
 
@@ -13,12 +14,9 @@ export const getTradePost = createAsyncThunk(
     { rejectWithValue },
   ) => {
     try {
-      const res = await axios.get<TradePostType>(
-        `${BASE_URL}/tradepost/${postId}`,
-        {
-          headers: auth(accessToken),
-        },
-      );
+      const res = await axiosI.get<TradePostType>(`/tradepost/${postId}`, {
+        headers: auth(accessToken),
+      });
       return res.data;
     } catch (err) {
       return rejectWithValue(err);


### PR DESCRIPTION
## 🙌 To Reviewers

- 제목 그대로 401 처리하는 axios instance를 만들었습니다.
- 아직 테스트를 못해봤는데 예지님 코드랑 머지해서 테스트를 해보면 될 것 같네요 (잘 안 될수도 있습니다..)
- 사용법은 저희가 기존에 쓰던 slice에서 `import {axiosI} from '../../api'` 한 다음에 axios -> axiosI로 바꿔주고, BASE_URL도 지워주면 됩니다 (instance 만들면서 base url 추가해두었기 때문)
- 일단 마켓 랜딩페이지 정보 불러오기 & 리뷰 보내기 & 트레이드포스트 정보 가져오기   이렇게 세 개의 요처안 axiosI로 바꿔두었습니다. 나머지는 테스트 이후 싹 바꾸는걸로 할게요

<br>

## 🔑 Key Changes

- 401 에러 처리하는 axios instance 생성

<br>

## ScreenShot (optional)

-
