### PR TITLE
fix: 로그인화면에서 홈으로 가기 / 거래필터 이름 변경

### DIFF
--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -126,7 +126,9 @@ const LoginPage = () => {
   return (
     <Wrapper>
       <Container>
-        <Title src={logoImg} />
+        <Link to="/">
+          <Title src={logoImg} />
+        </Link>
         <Input
           name="email"
           value={email}

--- a/src/pages/market/index.tsx
+++ b/src/pages/market/index.tsx
@@ -286,7 +286,7 @@ const MarketPage = () => {
         <Header>
           <Filter>
             <CheckBox type="checkbox" onChange={checkBoxChange} />
-            <Span>거래완료 상품 제외</Span>
+            <Span>거래가능만 보기</Span>
           </Filter>
           <SearchBar
             keyword={keyword}


### PR DESCRIPTION
## 🙌 To Reviewers

- 로그인 화면으로 리다이렉트 되면 빠져나오기가 어려워서 로고 누르면 홈으로 갈 수 있게 했어요
- 중고거래 랜딩 필터명을 '거래가능만 보기'로 바꿨어요

<br>

## 🔑 Key Changes

-

<br>

## ScreenShot (optional)

-
