### PR TITLE
fix: 판매내역에서 게시글 수정 z-index 추가 / 중고거래 글 작성 스로틀 시간 변경

### DIFF
--- a/src/components/trade-post-create/index.tsx
+++ b/src/components/trade-post-create/index.tsx
@@ -28,7 +28,7 @@ const TradePostCreate = ({
   imgObject,
   setImgObject,
 }: TradePostCreateProps) => {
-  const { isDisabled, throttle } = useThrottle(1000);
+  const { isDisabled, throttle } = useThrottle(5000);
   return (
     <S.ModalOuterLayout>
       <S.ModalLayout>

--- a/src/pages/sell-history-my/components/trade-post-update/styles.tsx
+++ b/src/pages/sell-history-my/components/trade-post-update/styles.tsx
@@ -8,6 +8,7 @@ export const ModalOuterLayout = styled.div`
   top: 0;
   align-items: center;
   justify-content: center;
+  z-index: 1001;
 `;
 
 export const ModalLayout = styled.div`


### PR DESCRIPTION
## 🙌 To Reviewers

- 모바일에서 중고거래 글 작성할 때 완료를 연타하면 두번 올라가는 버그가 있어서 스토릍 시간을 늘려봤습니다

<br>

## 🔑 Key Changes

-

<br>

## ScreenShot (optional)

-
